### PR TITLE
Enable 2to3 for setuptools installs.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,5 @@ setup(
     ],
     keywords = "python salesforce salesforce.com",
     classifiers=['Development Status :: 4 - Beta', 'Environment :: Console', 'Intended Audience :: Developers', 'Natural Language :: English', 'Operating System :: OS Independent', 'Topic :: Internet :: WWW/HTTP'],
+    use_2to3=True,
 )


### PR DESCRIPTION
Hey,

This instructs setuptools to use the 2to3 converter when used in python3 envs.  As I get more involved in using simple-salesforce in py3k-land I'm sure I'll find more issues but this changeset at least lets the module install and import.
