### PR TITLE
Use a reusable requests.Session object.

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -76,6 +76,7 @@ class Salesforce(object):
         else:
             self.auth_site = 'https://login.salesforce.com'
 
+        self.request = requests.Session()
         self.headers = {
             'Content-Type': 'application/json',
             'Authorization': 'Bearer ' + self.session_id,
@@ -115,7 +116,7 @@ class Salesforce(object):
 
         # `requests` will correctly encode the query string passed as `params`
         params = {'q': search}
-        result = requests.get(url, headers=self.headers, params=params)
+        result = self.request.get(url, headers=self.headers, params=params)
         if result.status_code != 200:
             raise SalesforceGeneralError(result.content)
         json_result = result.json()
@@ -150,8 +151,8 @@ class Salesforce(object):
         url = self.base_url + 'query/'
         params = {'q': query}
         # `requests` will correctly encode the query string passed as `params`
-        result = requests.get(url, headers=self.headers, params=params)
-        
+        result = self.request.get(url, headers=self.headers, params=params)
+ 
         if result.status_code != 200:
             _exception_handler(result)
 
@@ -180,7 +181,7 @@ class Salesforce(object):
         else:
             url = self.base_url + 'query/{next_record_id}'
             url = url.format(next_record_id=next_records_identifier)
-        result = requests.get(url, headers=self.headers)
+        result = self.request.get(url, headers=self.headers)
 
         if result.status_code != 200:
             _exception_handler(result)
@@ -347,7 +348,7 @@ class SFType(object):
             'Authorization': 'Bearer ' + self.session_id,
             'X-PrettyPrint': '1'
         }
-        result = requests.request(method, url, headers=headers, **kwargs)
+        result = self.request.request(method, url, headers=headers, **kwargs)
 
         if result.status_code >= 300:
             _exception_handler(result, self.name)


### PR DESCRIPTION
Reusing the same request.Session object provides better performance
for back-to-back queries as it lets urllib3 reuse the same socket when
appropriate.
