### PR TITLE
Added support for defining headers in SFType

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -164,7 +164,7 @@ class Salesforce(object):
         if name.startswith('__'):
             return super(Salesforce, self).__getattr__(name)
 
-        return SFType(name, self.session_id, self.sf_instance, self.sf_version, self.proxies)
+        return SFType(name, self.session_id, self.sf_instance, self.sf_version, self.proxies, self.headers)
 
     # User utlity methods
     def set_password(self, user, password):
@@ -394,7 +394,7 @@ class Salesforce(object):
 class SFType(object):
     """An interface to a specific type of SObject"""
 
-    def __init__(self, object_name, session_id, sf_instance, sf_version='27.0', proxies=None):
+    def __init__(self, object_name, session_id, sf_instance, sf_version='27.0', proxies=None, headers=None):
         """Initialize the instance with the given parameters.
 
         Arguments:
@@ -410,6 +410,12 @@ class SFType(object):
         self.name = object_name
         self.request = requests.Session()
         self.request.proxies = proxies
+
+        self.headers = headers if headers else {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer ' + self.session_id,
+              'X-PrettyPrint': '1'
+          }
 
         self.base_url = (u'https://{instance}/services/data/v{sf_version}/sobjects/{object_name}/'
                          .format(instance=sf_instance,
@@ -565,12 +571,8 @@ class SFType(object):
 
         Returns a `requests.result` object.
         """
-        headers = {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer ' + self.session_id,
-            'X-PrettyPrint': '1'
-        }
-        result = self.request.request(method, url, headers=headers, **kwargs)
+
+        result = self.request.request(method, url, headers=self.headers, **kwargs)
 
         if result.status_code >= 300:
             _exception_handler(result, self.name)

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -405,17 +405,19 @@ class SFType(object):
         * sf_instance -- the domain of the instance of Salesforce to use
         * sf_version -- the version of the Salesforce API to use
         * proxies -- the optional map of scheme to proxy server
+        * headers -- optional custom headers to pass in
         """
         self.session_id = session_id
         self.name = object_name
         self.request = requests.Session()
         self.request.proxies = proxies
 
-        self.headers = headers if headers else {
+        self.headers = {
               'Content-Type': 'application/json',
               'Authorization': 'Bearer ' + self.session_id,
               'X-PrettyPrint': '1'
           }
+        self.headers.update(headers) if headers else None
 
         self.base_url = (u'https://{instance}/services/data/v{sf_version}/sobjects/{object_name}/'
                          .format(instance=sf_instance,


### PR DESCRIPTION
Took a stab at a quick fix that would allow Sforce-auto-assign to be defined in the headers - I didn't necessarily want to make an argument just for sforce-auto-assign, so I took an approach where you could manually define/change the headers in Salesforce or SFType.

The code change simply allows SFType.headers to be defined and changed. The Salesforce get_attr function also passes in it's own headers to SFType.

To add, for example, Sforce-auto-assign to the headers, you could define it in the Salesforce API class headers and have it pass through to SFType like so:

```
>>> sf = simple_salesforce.Salesforce(sandbox=True, username=username, password=password, security_token=token)
>>> sf.headers
{'X-PrettyPrint': '1', 'Content-Type': 'application/json', 'Authorization': u'Bearer xxxx'}
>>>
>>> sf.headers['Sforce-auto-assign']=False
>>> sf.headers
{'Sforce-auto-assign': False, 'X-PrettyPrint': '1', 'Content-Type': 'application/json', 'Authorization': u'Bearer xxxx'}
>>>
>>> sf.Contact.headers
{'Sforce-auto-assign': False, 'X-PrettyPrint': '1', 'Content-Type': 'application/json', 'Authorization': u'Bearer xxxx'}
>>>

```

Unfortunately, this  makes the SFType headers a function of your API connection headers. If, for example, you wanted to auto assign Cases, but NOT auto assign Leads, you would either have to change your headers before each Case/Lead call, or create an SFType instance for each that defines the headers. The ultimate best solution might be to provide an argument to SFType calls (create, upsert, etc) where you can pass in custom headers.

