### PR TITLE
Fix defining of status and resource_name for SalesforceGeneralError

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -135,10 +135,10 @@ class Salesforce(object):
         url = self.base_url + "sobjects"
         result = self.request.get(url, headers=self.headers)
         if result.status_code != 200:
-            raise SalesforceGeneralError(url,
-                                         'describe',
-                                         result.status_code,
-                                         result.content)
+            raise SalesforceGeneralError(url=url,
+                                         resource_name='describe',
+                                         status=result.status_code,
+                                         content=result.content)
         json_result = result.json(object_pairs_hook=OrderedDict)
         if len(json_result) == 0:
             return None
@@ -186,10 +186,10 @@ class Salesforce(object):
 
         # salesforce return 204 No Content when the request is successful
         if result.status_code != 200 and result.status_code != 204:
-            raise SalesforceGeneralError(url,
-                                         'User',
-                                         result.status_code,
-                                         result.content)
+            raise SalesforceGeneralError(url=url,
+                                         resource_name='User',
+                                         status=result.status_code,
+                                         content=result.content)
         json_result = result.json(object_pairs_hook=OrderedDict)
         if len(json_result) == 0:
             return None
@@ -216,10 +216,10 @@ class Salesforce(object):
         url = self.base_url + path
         result = self.request.get(url, headers=self.headers, params=params)
         if result.status_code != 200:
-            raise SalesforceGeneralError(url,
-                                         path,
-                                         result.status_code,
-                                         result.content)
+            raise SalesforceGeneralError(url=url,
+                                         resource_name=path,
+                                         status=result.status_code,
+                                         content=result.content)
         json_result = result.json(object_pairs_hook=OrderedDict)
         if len(json_result) == 0:
             return None
@@ -242,10 +242,10 @@ class Salesforce(object):
         params = {'q': search}
         result = self.request.get(url, headers=self.headers, params=params)
         if result.status_code != 200:
-            raise SalesforceGeneralError(url,
-                                         'search',
-                                         result.status_code,
-                                         result.content)
+            raise SalesforceGeneralError(url=url,
+                                         resource_name='search',
+                                         status=result.status_code,
+                                         content=result.content)
         json_result = result.json(object_pairs_hook=OrderedDict)
         if len(json_result) == 0:
             return None
@@ -639,7 +639,10 @@ def _exception_handler(result, name=""):
     }
     exc_cls = exc_map.get(result.status_code, SalesforceGeneralError)
 
-    raise exc_cls(result.url, result.status_code, name, response_content)
+    raise exc_cls(url=result.url,
+                  status=result.status_code,
+                  resource_name=name,
+                  content=response_content)
 
 
 class SalesforceMoreThanOneRecord(SalesforceError):


### PR DESCRIPTION
Subj.
In other case, in raised SalesforceGeneralError exception, we have status with value of resource_name, and resource_name with value of status.
