### PR TITLE
Allow login without organizationId, serialize datetimes

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -104,7 +104,7 @@ class Salesforce(object):
                 self.sf_instance = instance
 
         elif all(arg is not None for arg in (
-                username, password, organizationId)):
+                username, password)):
             self.auth_type = 'ipfilter'
 
             # Pass along the username/password to our login helper


### PR DESCRIPTION
Using an API account in an org where access is restricted by IP ranges, I was unable to authenticate, with an error response of

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
                  xmlns:sf="urn:fault.partner.soap.sforce.com"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <soapenv:Body>
    <soapenv:Fault>
      <faultcode>sf:INVALID_LOGIN</faultcode>
      <faultstring>INVALID_LOGIN: Invalid username, password, security token; or user locked out.</faultstring>
      <detail>
        <sf:LoginFault xsi:type="sf:LoginFault">
          <sf:exceptionCode>INVALID_LOGIN</sf:exceptionCode>
          <sf:exceptionMessage>Invalid username, password, security token; or user locked out.</sf:exceptionMessage>
        </sf:LoginFault>
      </detail>
    </soapenv:Fault>
  </soapenv:Body>
</soapenv:Envelope>
```

After some back-and-forth with SFDC support, the issue turned out to be that this part of the SOAP login request should not be included:

``` xml
<urn:LoginScopeHeader>
  <urn:organizationId>{organizationId}</urn:organizationId>
</urn:LoginScopeHeader>
```

This patch makes an `organizationId` optional. It resolved the issue I was experiencing, now login is successful.
