### PR TITLE
Share requests.Session across SFType instances

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -73,7 +73,10 @@ class Salesforce(object):
         # kwargs
         self.sf_version = version
         self.sandbox = sandbox
-        self.proxies = proxies
+        self.request = session or requests.Session()
+        self.proxies = self.request.proxies
+        if proxies is not None:  # override custom session proxies dance
+            self.request.proxies = self.proxies = proxies
 
         # Determine if the user wants to use our username/password auth or pass
         # in their own information
@@ -83,7 +86,7 @@ class Salesforce(object):
 
             # Pass along the username/password to our login helper
             self.session_id, self.sf_instance = SalesforceLogin(
-                session=session,
+                session=self.request,
                 username=username,
                 password=password,
                 security_token=security_token,
@@ -110,7 +113,7 @@ class Salesforce(object):
 
             # Pass along the username/password to our login helper
             self.session_id, self.sf_instance = SalesforceLogin(
-                session=session,
+                session=self.request,
                 username=username,
                 password=password,
                 organizationId=organizationId,
@@ -129,8 +132,6 @@ class Salesforce(object):
         else:
             self.auth_site = 'https://login.salesforce.com'
 
-        self.request = session or requests.Session()
-        self.request.proxies = self.proxies
         self.headers = {
             'Content-Type': 'application/json',
             'Authorization': 'Bearer ' + self.session_id,

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -64,7 +64,7 @@ class Salesforce(object):
                      `29.0`
         * proxies -- the optional map of scheme to proxy server
         * session -- Custom requests session, created in calling code. This
-                     enables the use of requets Session features not otherwise
+                     enables the use of requests Session features not otherwise
                      exposed by simple_salesforce.
 
         """
@@ -180,8 +180,8 @@ class Salesforce(object):
             return super(Salesforce, self).__getattr__(name)
 
         return SFType(
-            name, self.session_id, self.sf_instance, self.sf_version,
-            self.proxies)
+            name, self.session_id, self.sf_instance, sf_version=self.sf_version,
+            proxies=self.proxies, session=self.request)
 
     # User utlity methods
     def set_password(self, user, password):
@@ -432,7 +432,7 @@ class SFType(object):
     # pylint: disable=too-many-arguments
     def __init__(
             self, object_name, session_id, sf_instance, sf_version='27.0',
-            proxies=None):
+            proxies=None, session=None):
         """Initialize the instance with the given parameters.
 
         Arguments:
@@ -443,11 +443,15 @@ class SFType(object):
         * sf_instance -- the domain of the instance of Salesforce to use
         * sf_version -- the version of the Salesforce API to use
         * proxies -- the optional map of scheme to proxy server
+        * session -- Custom requests session, created in calling code. This
+                     enables the use of requests Session features not otherwise
+                     exposed by simple_salesforce.
         """
         self.session_id = session_id
         self.name = object_name
-        self.request = requests.Session()
-        self.request.proxies = proxies
+        self.request = session or requests.Session()
+        if proxies is not None:  # don't wipe out original proxies with None
+            self.request.proxies = proxies
 
         self.base_url = (
             u'https://{instance}/services/data/v{sf_version}/sobjects'

--- a/simple_salesforce/tests/__init__.py
+++ b/simple_salesforce/tests/__init__.py
@@ -4,6 +4,10 @@
 SESSION_ID = '12345'
 METADATA_URL = 'https://na15.salesforce.com/services/Soap/m/29.0/00Di0000000icUB'
 SERVER_URL = 'https://na15.salesforce.com/services/Soap/c/29.0/00Di0000000icUB/0DFi00000008UYO'
+PROXIES = {
+    "http": "http://10.10.1.10:3128",
+    "https": "http://10.10.1.10:1080",
+}
 
 LOGIN_RESPONSE_SUCCESS = """<?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="urn:enterprise.soap.sforce.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -69,7 +69,7 @@ class TestSalesforce(unittest.TestCase):
             security_token='token')
 
         self.assertEqual(tests.SESSION_ID, client.session_id)
-        self.assertEqual(session, client.request)
+        self.assertEqual(session, client.session)
 
     @responses.activate
     def test_custom_version_success(self):
@@ -96,7 +96,7 @@ class TestSalesforce(unittest.TestCase):
         client = Salesforce(session_id=tests.SESSION_ID,
                             instance_url=tests.SERVER_URL)
 
-        self.assertIs(client.request, client.Contact.request)
+        self.assertIs(client.session, client.Contact.session)
 
     def test_shared_custom_session_to_sftype(self):
         """Test Salesforce and SFType instances share custom `Session`"""
@@ -105,8 +105,8 @@ class TestSalesforce(unittest.TestCase):
                             instance_url=tests.SERVER_URL,
                             session=session)
 
-        self.assertIs(session, client.request)
-        self.assertIs(session, client.Contact.request)
+        self.assertIs(session, client.session)
+        self.assertIs(session, client.Contact.session)
 
     def test_proxies_inherited_default(self):
         """Test Salesforce and SFType use same proxies"""
@@ -115,8 +115,8 @@ class TestSalesforce(unittest.TestCase):
                             instance_url=tests.SERVER_URL,
                             session=session)
 
-        self.assertIs(session.proxies, client.request.proxies)
-        self.assertIs(session.proxies, client.Contact.request.proxies)
+        self.assertIs(session.proxies, client.session.proxies)
+        self.assertIs(session.proxies, client.Contact.session.proxies)
 
     def test_proxies_inherited_set_on_session(self):
         """Test Salesforce and SFType use same custom proxies"""
@@ -125,8 +125,8 @@ class TestSalesforce(unittest.TestCase):
         client = Salesforce(session_id=tests.SESSION_ID,
                             instance_url=tests.SERVER_URL,
                             session=session)
-        self.assertIs(tests.PROXIES, client.request.proxies)
-        self.assertIs(tests.PROXIES, client.Contact.request.proxies)
+        self.assertIs(tests.PROXIES, client.session.proxies)
+        self.assertIs(tests.PROXIES, client.Contact.session.proxies)
 
 
 class TestExceptionHandler(unittest.TestCase):

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -91,6 +91,43 @@ class TestSalesforce(unittest.TestCase):
         self.assertEqual(
             client.base_url.split('/')[-2], 'v%s' % expected_version)
 
+    def test_shared_session_to_sftype(self):
+        """Test Salesforce and SFType instances share default `Session`"""
+        client = Salesforce(session_id=tests.SESSION_ID,
+                            instance_url=tests.SERVER_URL)
+
+        self.assertIs(client.request, client.Contact.request)
+
+    def test_shared_custom_session_to_sftype(self):
+        """Test Salesforce and SFType instances share custom `Session`"""
+        session = requests.Session()
+        client = Salesforce(session_id=tests.SESSION_ID,
+                            instance_url=tests.SERVER_URL,
+                            session=session)
+
+        self.assertIs(session, client.request)
+        self.assertIs(session, client.Contact.request)
+
+    def test_proxies_inherited_default(self):
+        """Test Salesforce and SFType use same proxies"""
+        session = requests.Session()
+        client = Salesforce(session_id=tests.SESSION_ID,
+                            instance_url=tests.SERVER_URL,
+                            session=session)
+
+        self.assertIs(session.proxies, client.request.proxies)
+        self.assertIs(session.proxies, client.Contact.request.proxies)
+
+    def test_proxies_inherited_set_on_session(self):
+        """Test Salesforce and SFType use same custom proxies"""
+        session = requests.Session()
+        session.proxies = tests.PROXIES
+        client = Salesforce(session_id=tests.SESSION_ID,
+                            instance_url=tests.SERVER_URL,
+                            session=session)
+        self.assertIs(tests.PROXIES, client.request.proxies)
+        self.assertIs(tests.PROXIES, client.Contact.request.proxies)
+
 
 class TestExceptionHandler(unittest.TestCase):
     """Test the exception router"""


### PR DESCRIPTION
Fixes #91 

I was a bit more explicit in the creation of `SFType` and specified parameter names instead of relying on their position. I hope that is OK.