### PR TITLE
Allow custom HTTP headers when calling the update() method

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -543,7 +543,7 @@ class SFType(object):
                                        data=json.dumps(data))
         return self._raw_response(result, raw_response)
 
-    def update(self, record_id, data, raw_response=False):
+    def update(self, record_id, data, raw_response=False, **kwargs):
         """Updates an SObject using a PATCH to
         `.../{object_name}/{record_id}`.
 
@@ -560,7 +560,7 @@ class SFType(object):
                           directly, instead of the status code.
         """
         result = self._call_salesforce('PATCH', self.base_url + record_id,
-                                       data=json.dumps(data))
+                                       data=json.dumps(data), **kwargs)
         return self._raw_response(result, raw_response)
 
     def delete(self, record_id, raw_response=False):
@@ -623,6 +623,7 @@ class SFType(object):
             'Authorization': 'Bearer ' + self.session_id,
             'X-PrettyPrint': '1'
         }
+        headers.update(kwargs.pop('headers', dict()))
         result = self.request.request(method, url, headers=headers, **kwargs)
 
         if result.status_code >= 300:


### PR DESCRIPTION
There are some cases where the user needs to pass a custom HTTP header when making a record update request.  The situation I ran into was passing the custom "Sforce-Auto-Assign" header when updating a lead to prevent auto-assign rules from running:

https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/headers_autoassign.htm

This trivial library change allows the user to pass custom headers; for example, in the situation above:

    sf.Lead.update(lead_id, lead_updates, headers={'Sforce-Auto-Assign': 'FALSE'})