### PR TITLE
Update setup.py and travis with new repo location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ deploy:
   on:
     tags: true
     all_branches: true
-    repo: heroku/simple-salesforce
+    repo: simple-salesforce/simple-salesforce
 env:
   - TOXENV=unit
   - TOXENV=static

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,10 @@ if sys.version_info < (3, 0):
 
 setup(
     name='simple-salesforce',
-    version='0.68.1',
+    version='0.68.2',
     author='Nick Catalano',
     packages=['simple_salesforce',],
-    url='https://github.com/heroku/simple-salesforce',
+    url='https://github.com/simple-salesforce/simple-salesforce',
     license='Apache 2.0',
     description=("Simple Salesforce is a basic Salesforce.com REST API client. "
         "The goal is to provide a very low-level interface to the API, "


### PR DESCRIPTION
@demianbrecht this pull request *should* appear as passing on the travis site under `simple-salesforce/simple-salesforce` as we as on this pull request itself

Once merged in we need to create a tag/release called `v0.68.2` to confirm the automated pypi deploy works