### PR TITLE
Expose the api limits and usage header from the response

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -447,9 +447,8 @@ class Salesforce(object):
 
         api_usage = re.match(r'[^-]?api-usage=(?P<used>\d+)/(?P<tot>\d+)',
                              sforce_limit_info)
-        u = r'per-app-api-usage=(?P<used>\d+)/(?P<tot>\d+)' \
-            r'\(appName=(?P<name>.+)\)'
-        per_app_api_usage = re.match(u, sforce_limit_info)
+        pau = r'.+per-app-api-usage=(?P<u>\d+)/(?P<t>\d+)\(appName=(?P<n>.+)\)'
+        per_app_api_usage = re.match(pau, sforce_limit_info)
 
         if api_usage and api_usage.groups():
             result['api-usage'] = [int(n) for n in  api_usage.groups()]

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -29,7 +29,9 @@ from simple_salesforce.api import (
     SalesforceExpiredSession,
     SalesforceRefusedRequest,
     SalesforceResourceNotFound,
-    SalesforceGeneralError
+    SalesforceGeneralError,
+    Usage,
+    PerAppUsage
 )
 
 
@@ -108,9 +110,7 @@ class TestSalesforce(unittest.TestCase):
         client.base_url = 'https://localhost'
         client.query('q')
 
-        self.assertDictEqual(client.api_usage,
-                             {'api-usage': [18, 5000],
-                              'Sforce-Limit-Info': 'api-usage=18/5000'})
+        self.assertDictEqual(client.api_usage, {'api-usage': Usage(18, 5000)})
 
     @responses.activate
     def test_api_usage_per_app(self):
@@ -132,9 +132,9 @@ class TestSalesforce(unittest.TestCase):
         client.query('q')
 
         self.assertDictEqual(client.api_usage,
-                             {'api-usage': [25, 5000],
-                              'per-app-api-usage': [17, 250, 'sample-app'],
-                              'Sforce-Limit-Info': pau})
+                             {'api-usage': Usage(25, 5000),
+                              'per-app-api-usage': PerAppUsage(17, 250,
+                                                               'sample-app')})
 
 
 class TestExceptionHandler(unittest.TestCase):


### PR DESCRIPTION
This resolves #118 by recording api usage so that we can monitor it without needing to make extra requests.

Example usage: 

``` python
>>> import simple_salesforce
>>> salesforce_client = simple_salesforce.Salesforce( <credentials> )
>>> a = salesforce_client.Account
>>> q = 'SELECT SystemModstamp FROM Account WHERE SystemModstamp > 2016-06-20T00:00:00Z LIMIT 10'
>>> _ = salesforce_client.query(q)
>>> salesforce_client.api_usage
{'api-usage': Usage(used=18, total=5000)}
>>> _ = a.describe()
>>> a.api_usage
{'api-usage': Usage(used=19, total=5000)}
```
