### PR TITLE
Add Client Id To Identify API Source

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,15 @@ For example:
 
 Note that specifying if you want to use a sandbox is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
 
+If you'd like to keep track where your API calls are coming from, simply add ``client_id='My App'`` to your ``Salesforce()`` call.
+
+.. code-block:: python
+
+    from simple_salesforce import Salesforce
+    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', sandbox=True, client_id='My App')
+
+If you view the API calls in your Salesforce instance by Client Id it will be prefixed with ``RestForce/``, for example ``RestForce/My App``.
+
 When instantiating a `Salesforce` object, it's also possible to include an
 instance of `requests.Session`. This is to allow for specialized
 session handling not otherwise exposed by simple_salesforce.

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -35,7 +35,7 @@ class Salesforce(object):
             self, username=None, password=None, security_token=None,
             session_id=None, instance=None, instance_url=None,
             organizationId=None, sandbox=False, version=DEFAULT_API_VERSION,
-            proxies=None, session=None):
+            proxies=None, session=None, client_id=None):
         """Initialize the instance with the given parameters.
 
         Available kwargs
@@ -89,7 +89,8 @@ class Salesforce(object):
                 security_token=security_token,
                 sandbox=self.sandbox,
                 sf_version=self.sf_version,
-                proxies=self.proxies)
+                proxies=self.proxies,
+                client_id=client_id)
 
         elif all(arg is not None for arg in (
                 session_id, instance or instance_url)):
@@ -115,7 +116,8 @@ class Salesforce(object):
                 organizationId=organizationId,
                 sandbox=self.sandbox,
                 sf_version=self.sf_version,
-                proxies=self.proxies)
+                proxies=self.proxies,
+                client_id=client_id)
 
         else:
             raise TypeError(

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -49,8 +49,8 @@ def SalesforceLogin(
 
     if client_id:
         client_id = "{prefix}/{app_name}".format(
-                        prefix=DEFAULT_CLIENT_ID_PREFIX,
-                        app_name=client_id)
+            prefix=DEFAULT_CLIENT_ID_PREFIX,
+            app_name=client_id)
     else:
         client_id = DEFAULT_CLIENT_ID_PREFIX
 

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -2,6 +2,10 @@
 
 Heavily Modified from RestForce 1.0.0
 """
+
+DEFAULT_CLIENT_ID_PREFIX = 'RestForce'
+
+
 from simple_salesforce.api import DEFAULT_API_VERSION
 from simple_salesforce.util import getUniqueElementValueFromXmlString
 from simple_salesforce.util import SalesforceError
@@ -17,7 +21,7 @@ import requests
 def SalesforceLogin(
         username=None, password=None, security_token=None,
         organizationId=None, sandbox=False, sf_version=DEFAULT_API_VERSION,
-        proxies=None, session=None):
+        proxies=None, session=None, client_id=None):
     """Return a tuple of `(session_id, sf_instance)` where `session_id` is the
     session ID to use for authentication to Salesforce and `sf_instance` is
     the domain of the instance of Salesforce to use for the session.
@@ -37,10 +41,18 @@ def SalesforceLogin(
     * session -- Custom requests session, created in calling code. This
                  enables the use of requets Session features not otherwise
                  exposed by simple_salesforce.
+    * client_id -- the ID of this client
     """
 
     soap_url = 'https://{domain}.salesforce.com/services/Soap/u/{sf_version}'
     domain = 'test' if sandbox else 'login'
+
+    if client_id:
+        client_id = "{prefix}/{app_name}".format(
+                        prefix=DEFAULT_CLIENT_ID_PREFIX,
+                        app_name=client_id)
+    else:
+        client_id = DEFAULT_CLIENT_ID_PREFIX
 
     soap_url = soap_url.format(domain=domain, sf_version=sf_version)
 
@@ -56,7 +68,14 @@ def SalesforceLogin(
         <env:Envelope
                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+                xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"
+                xmlns:urn="urn:partner.soap.sforce.com">
+            <env:Header>
+                <urn:CallOptions>
+                    <urn:client>{client_id}</urn:client>
+                    <urn:defaultNamespace>sf</urn:defaultNamespace>
+                </urn:CallOptions>
+            </env:Header>
             <env:Body>
                 <n1:login xmlns:n1="urn:partner.soap.sforce.com">
                     <n1:username>{username}</n1:username>
@@ -64,7 +83,8 @@ def SalesforceLogin(
                 </n1:login>
             </env:Body>
         </env:Envelope>""".format(
-            username=username, password=password, token=security_token)
+            username=username, password=password, token=security_token,
+            client_id=client_id)
 
     # Check if IP Filtering is used in conjuction with organizationId
     elif organizationId is not None:
@@ -75,7 +95,7 @@ def SalesforceLogin(
                 xmlns:urn="urn:partner.soap.sforce.com">
             <soapenv:Header>
                 <urn:CallOptions>
-                    <urn:client>RestForce</urn:client>
+                    <urn:client>{client_id}</urn:client>
                     <urn:defaultNamespace>sf</urn:defaultNamespace>
                 </urn:CallOptions>
                 <urn:LoginScopeHeader>
@@ -89,7 +109,8 @@ def SalesforceLogin(
                 </urn:login>
             </soapenv:Body>
         </soapenv:Envelope>""".format(
-            username=username, password=password, organizationId=organizationId)
+            username=username, password=password, organizationId=organizationId,
+            client_id=client_id)
     elif username is not None and password is not None:
         # IP Filtering for non self-service users
         login_soap_request_body = """<?xml version="1.0" encoding="utf-8" ?>
@@ -98,7 +119,7 @@ def SalesforceLogin(
                 xmlns:urn="urn:partner.soap.sforce.com">
             <soapenv:Header>
                 <urn:CallOptions>
-                    <urn:client>RestForce</urn:client>
+                    <urn:client>{client_id}</urn:client>
                     <urn:defaultNamespace>sf</urn:defaultNamespace>
                 </urn:CallOptions>
             </soapenv:Header>
@@ -109,7 +130,7 @@ def SalesforceLogin(
                 </urn:login>
             </soapenv:Body>
         </soapenv:Envelope>""".format(
-            username=username, password=password)
+            username=username, password=password, client_id=client_id)
     else:
         except_code = 'INVALID AUTH'
         except_msg = (


### PR DESCRIPTION
Adding a client Id to the SOAP Header will allow API calls in Salesforce to be grouped by client Id, and thus identifiable when viewing the "breakdown of API calls." This is great when you need to analyze how many API calls each of your apps are making, especially projecting if you need to adjust your maximum API requests associated with your account.

Currently when you view a report on recent API calls segmented by Client Id, calls made by `simple_salesforce` are identified by a Client Id of `-`.