### PR TITLE
Provide support for access_token refresh for flows (like OAuth2) that granted a refresh_token to a Connected App

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,12 +31,12 @@ If you have the full URL of your instance (perhaps including the schema, as is i
     from simple_salesforce import Salesforce
     sf = Salesforce(instance_url='https://na1.salesforce.com', session_id='')
 
-If you have a Connected App and Refresh token (as included in some OAuth2 request processes), you can also pass in the ``client_id``, ``client_secret`` and ``refresh_token`` to have simple-salesforce attempt to refresh the session/access token if it expires:
+If you have a Connected App and Refresh token (as included in some OAuth2 request processes), you can also pass in the ``consumer_id``, ``consumer_secret`` and ``refresh_token`` to have simple-salesforce attempt to refresh the session/access token if it expires:
 
 .. code-block:: python
 
     from simple_salesforce import Salesforce
-    sf = Salesforce(instance='na1.salesforce.com', session_id='', client_id='MY_CONNECTED_APP_ID', client_secret='MY_CONNECTED_APP_SECRET', refresh_token='REFRESH_TOKEN_PROVIDED_DURING_A_PRIOR_AUTH')
+    sf = Salesforce(instance='na1.salesforce.com', session_id='', consumer_id='MY_CONNECTED_APP_ID', consumer_secret='MY_CONNECTED_APP_SECRET', refresh_token='REFRESH_TOKEN_PROVIDED_DURING_A_PRIOR_AUTH')
 
 2) There are also two means of authentication: uses username, password and security token uses IP filtering, username, password and organizationId
 
@@ -259,7 +259,7 @@ Additional Features
 
 There are a few helper classes that are used internally and available to you.
 
-Included in them are ``SalesforceLogin``, which takes in either: \[a username, password and security token\] OR \[a client_id, client_secret and refresh_token\] and optional boolean sandbox indicator and optional version and returns a touple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
+Included in them are ``SalesforceLogin``, which takes in either: \[a username, password and security token\] OR \[a consumer_id, consumer_secret and refresh_token\] and optional boolean sandbox indicator and optional version and returns a touple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
 
 For example, to use SalesforceLogin with a username, password and security_token for a sandbox account you'd use:
 
@@ -274,14 +274,14 @@ For example, to use SalesforceLogin with a username, password and security_token
 
 Simply leave off the final ``True`` if you do not wish to use a sandbox.
 
-To use SalesforceLogin with a client_id, client_secret and refresh_token for a sandbox account you'd use:
+To use SalesforceLogin with a consumer_id, consumer_secret and refresh_token for a sandbox account you'd use:
 
 .. code-block:: python
 
     from simple_salesforce import SalesforceLogin
     session_id, instance = SalesforceLogin(
-        client_id='MY_CONNECTED_APP_ID',
-        client_secret='MY_CONNECTED_APP_SECRET',
+        consumer_id='MY_CONNECTED_APP_ID',
+        consumer_secret='MY_CONNECTED_APP_SECRET',
         refresh_token='REFRESH_TOKEN_PROVIDED_DURING_A_PRIOR_AUTH'
         sandbox=True)
 

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Example
 -------
 There are two ways to gain access to Salesforce
 
-The first is to simply pass the domain of your Salesforce instance and an access token straight to ``Salesforce()``
+1) The first is to simply pass the domain of your Salesforce instance and an access token straight to ``Salesforce()``
 
 For example:
 
@@ -31,10 +31,14 @@ If you have the full URL of your instance (perhaps including the schema, as is i
     from simple_salesforce import Salesforce
     sf = Salesforce(instance_url='https://na1.salesforce.com', session_id='')
 
-There are also three means of authentication\:
-    1) uses username, password and security token
-    2) uses IP filtering, username, password and organizationId
-    3) uses client_id, client_secret and a refresh_token (retrieved from a prior OAuth)
+If you have a Connected App and Refresh token (as included in some OAuth2 request processes), you can also pass in the ``client_id``, ``client_secret`` and ``refresh_token`` to have simple-salesforce attempt to refresh the session/access token if it expires:
+
+.. code-block:: python
+
+    from simple_salesforce import Salesforce
+    sf = Salesforce(instance='na1.salesforce.com', session_id='', client_id='MY_CONNECTED_APP_ID', client_secret='MY_CONNECTED_APP_SECRET', refresh_token='REFRESH_TOKEN_PROVIDED_DURING_A_PRIOR_AUTH')
+
+2) There are also two means of authentication: uses username, password and security token uses IP filtering, username, password and organizationId
 
 To login using the security token method, simply include the Salesforce method and pass in your Salesforce username, password and token (this is usually provided when you change your password):
 
@@ -49,13 +53,6 @@ To login using IP-whitelist Organization ID method, simply use your Salesforce u
 
     from simple_salesforce import Salesforce
     sf = Salesforce(password='password', username='myemail@example.com', organizationId='OrgId')
-
-To login using Client Id, Client Secret and Refresh Token, simply provide the client_id, client_secret and refresh_token:
-
-.. code-block:: python
-
-    from simple_salesforce import Salesforce
-    sf = Salesforce(client_id='MY_CONNECTED_APP_ID', client_secret='MY_CONNECTED_APP_SECRET', refresh_token='REFRESH_TOKEN_PROVIDED_DURING_A_PRIOR_AUTH')
 
 If you'd like to enter a sandbox, simply add ``sandbox=True`` to your ``Salesforce()`` call.
 

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,10 @@ If you have the full URL of your instance (perhaps including the schema, as is i
     from simple_salesforce import Salesforce
     sf = Salesforce(instance_url='https://na1.salesforce.com', session_id='')
 
-There are also two means of authentication, one that uses username, password and security token and the other that uses IP filtering, username, password  and organizationId
+There are also three means of authentication\:
+    1) uses username, password and security token
+    2) uses IP filtering, username, password and organizationId
+    3) uses client_id, client_secret and a refresh_token (retrieved from a prior OAuth)
 
 To login using the security token method, simply include the Salesforce method and pass in your Salesforce username, password and token (this is usually provided when you change your password):
 
@@ -46,6 +49,13 @@ To login using IP-whitelist Organization ID method, simply use your Salesforce u
 
     from simple_salesforce import Salesforce
     sf = Salesforce(password='password', username='myemail@example.com', organizationId='OrgId')
+
+To login using Client Id, Client Secret and Refresh Token, simply provide the client_id, client_secret and refresh_token:
+
+.. code-block:: python
+
+    from simple_salesforce import Salesforce
+    sf = Salesforce(client_id='MY_CONNECTED_APP_ID', client_secret='MY_CONNECTED_APP_SECRET', refresh_token='REFRESH_TOKEN_PROVIDED_DURING_A_PRIOR_AUTH')
 
 If you'd like to enter a sandbox, simply add ``sandbox=True`` to your ``Salesforce()`` call.
 
@@ -243,9 +253,9 @@ Additional Features
 
 There are a few helper classes that are used internally and available to you.
 
-Included in them are ``SalesforceLogin``, which takes in a username, password, security token, optional boolean sandbox indicator and optional version and returns a touple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
+Included in them are ``SalesforceLogin``, which takes in either: \[a username, password and security token\] OR \[a client_id, client_secret and refresh_token\] and optional boolean sandbox indicator and optional version and returns a touple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
 
-For example, to use SalesforceLogin for a sandbox account you'd use:
+For example, to use SalesforceLogin with a username, password and security_token for a sandbox account you'd use:
 
 .. code-block:: python
 
@@ -254,6 +264,19 @@ For example, to use SalesforceLogin for a sandbox account you'd use:
         username='myemail@example.com.sandbox',
         password='password',
         security_token='token',
+        sandbox=True)
+
+Simply leave off the final ``True`` if you do not wish to use a sandbox.
+
+To use SalesforceLogin with a client_id, client_secret and refresh_token for a sandbox account you'd use:
+
+.. code-block:: python
+
+    from simple_salesforce import SalesforceLogin
+    session_id, instance = SalesforceLogin(
+        client_id='MY_CONNECTED_APP_ID',
+        client_secret='MY_CONNECTED_APP_SECRET',
+        refresh_token='REFRESH_TOKEN_PROVIDED_DURING_A_PRIOR_AUTH'
         sandbox=True)
 
 Simply leave off the final ``True`` if you do not wish to use a sandbox.

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Example
 -------
 There are two ways to gain access to Salesforce
 
-1) The first is to simply pass the domain of your Salesforce instance and an access token straight to ``Salesforce()``
+1) The first is to simply pass the domain of your Salesforce instance and an access token straight to ``Salesforce()``. NOTE: ``session_id`` here is also known as ``access_token`` in some flows.
 
 For example:
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -478,9 +478,9 @@ class Salesforce(object):
 
                     # Let's try to refresh the access_token
                     session_id, sf_instance = SalesforceLogin(
-                            refresh_token=self.refresh_token,
-                            consumer_id=self.consumer_id,
-                            consumer_secret=self.consumer_secret)
+                        refresh_token=self.refresh_token,
+                        consumer_id=self.consumer_id,
+                        consumer_secret=self.consumer_secret)
 
                     # If it looks like things went well:
                     if session_id and sf_instance:

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -40,7 +40,7 @@ class Salesforce(object):
     def __init__(
             self, username=None, password=None, security_token=None,
             session_id=None, instance=None, instance_url=None,
-            refresh_token=None, client_id=None, client_secret=None,
+            refresh_token=None, consumer_id=None, consumer_secret=None,
             organizationId=None, sandbox=False, version=DEFAULT_API_VERSION,
             proxies=None, session=None, client_id=None):
         """Initialize the instance with the given parameters.
@@ -70,8 +70,8 @@ class Salesforce(object):
             * Optionally include ALL below for refreshable tokens given to
                 Connected Apps:
 
-                * client_id -- Your Connected App's public key identifier
-                * client_secret -- Your Connected App's private key identifier
+                * consumer_id -- Your Connected App's public key identifier
+                * consumer_secret -- Your Connected App's private key identifier
                 * refresh_token -- The refresh token provided as part of the
                     response to your app's OAuth authentication process.
 
@@ -125,12 +125,12 @@ class Salesforce(object):
             # then this session/access_token is refreshable and we may need to
             # utilize this if session expires
             if all(arg is not None for arg in (
-                refresh_token, client_id, client_secret)):
+                refresh_token, consumer_id, consumer_secret)):
 
                 self.auth_type = AUTH_TYPE_DIRECT_WITH_REFRESH
                 self.refresh_token = refresh_token
-                self.client_id = client_id
-                self.client_secret = client_secret
+                self.consumer_id = consumer_id
+                self.consumer_secret = consumer_secret
 
 
         elif all(arg is not None for arg in (
@@ -477,8 +477,8 @@ class Salesforce(object):
                     # Let's try to refresh the access_token
                     session_id, sf_instance = SalesforceLogin(
                                             refresh_token=self.refresh_token,
-                                            client_id=self.client_id,
-                                            client_secret=self.client_secret)
+                                            consumer_id=self.consumer_id,
+                                            consumer_secret=self.consumer_secret)
 
                     # If it looks like things went well:
                     if session_id and sf_instance:

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -36,7 +36,7 @@ class Salesforce(object):
     An instance of Salesforce is a handy way to wrap a Salesforce session
     for easy use of the Salesforce REST API.
     """
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-locals
     def __init__(
             self, username=None, password=None, security_token=None,
             session_id=None, instance=None, instance_url=None,
@@ -78,11 +78,11 @@ class Salesforce(object):
 
         Universal Kwargs:
             * version -- the version of the Salesforce API to use, for example
-                         `29.0`
+                        `29.0`
             * proxies -- the optional map of scheme to proxy server
             * session -- Custom requests session, created in calling code. This
-                         enables the use of requets Session features not otherwise
-                         exposed by simple_salesforce.
+                        enables the use of requets Session features not
+                        otherwiseexposed by simple_salesforce.
 
         """
 
@@ -125,7 +125,7 @@ class Salesforce(object):
             # then this session/access_token is refreshable and we may need to
             # utilize this if session expires
             if all(arg is not None for arg in (
-                refresh_token, consumer_id, consumer_secret)):
+                    refresh_token, consumer_id, consumer_secret)):
 
                 self.auth_type = AUTH_TYPE_DIRECT_WITH_REFRESH
                 self.refresh_token = refresh_token
@@ -171,7 +171,9 @@ class Salesforce(object):
 
 
     def _build_headers(self):
-        """Build the headers we add to each request that includes access token"""
+        """
+        Build the headers we add to each request that includes access token
+        """
         self.headers = {
             'Content-Type': 'application/json',
             'Authorization': 'Bearer ' + self.session_id,
@@ -476,21 +478,23 @@ class Salesforce(object):
 
                     # Let's try to refresh the access_token
                     session_id, sf_instance = SalesforceLogin(
-                                            refresh_token=self.refresh_token,
-                                            consumer_id=self.consumer_id,
-                                            consumer_secret=self.consumer_secret)
+                            refresh_token=self.refresh_token,
+                            consumer_id=self.consumer_id,
+                            consumer_secret=self.consumer_secret)
 
                     # If it looks like things went well:
                     if session_id and sf_instance:
-                        # Store the new session ID and rebuild the headers to use it
+                        # Store the new session ID and rebuild the headers
+                        # to use it
                         self.session_id = session_id
                         self._build_headers()
-                        # Replace the old instance URL with the new one for this call
-                        # and then store it internally for future calls
+                        # Replace the old instance URL with the new one for this
+                        # call and then store it internally for future calls
                         url = url.replace(self.sf_instance, sf_instance)
                         self.sf_instance = sf_instance
 
-                        # Continue through the loop again, hopefully with success
+                        # Continue through the loop again, hopefully
+                        # with success
                         continue
 
                 # If we got here, it's a plain fat old exception

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -52,8 +52,8 @@ class Salesforce(object):
             * username -- the Salesforce username to use for authentication
             * password -- the password for the username
             * security_token -- the security token for the username
-            * sandbox -- True if you want to login to `test.salesforce.com`, False
-                         if you want to login to `login.salesforce.com`.
+            * sandbox -- True if you want to login to `test.salesforce.com` or
+                False if you want to login to `login.salesforce.com`.
 
 
         Direct Session and Instance Access:
@@ -474,10 +474,9 @@ class Salesforce(object):
 
                     # Let's try to refresh the access_token
                     session_id, sf_instance = SalesforceLogin(
-                                                refresh_token=self.refresh_token,
-                                                client_id=self.client_id,
-                                                client_secret=self.client_secret
-                                            )
+                                            refresh_token=self.refresh_token,
+                                            client_id=self.client_id,
+                                            client_secret=self.client_secret)
 
                     # If it looks like things went well:
                     if session_id and sf_instance:

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -16,7 +16,7 @@ except ImportError:
     from cgi import escape
 import requests
 
-
+# pylint: disable=invalid-name
 def cleanseInstanceUrl(instance_url):
     """Remove some common/likely noise from an instance url"""
     return (instance_url
@@ -46,10 +46,10 @@ def SalesforceLogin(
 
     * refresh_token -- the refresh token provided to the Connected App (used in
         some OAuth schemes)
-    * consumer_id -- the consumer ID for the Connected App that was granted user's
-        refresh token
-    * consumer_secret -- the consumer secret for the Connected App that was granted the
-        user's refresh token.
+    * consumer_id -- the consumer ID for the Connected App that was granted
+        user's refresh token
+    * consumer_secret -- the consumer secret for the Connected App that was
+        granted the user's refresh token.
 
 
     * organizationId -- the ID of your organization
@@ -82,7 +82,8 @@ def SalesforceLogin(
 
     # Let's see if this flow is appropriate first as it's quite different
     # than the rest of the flows
-    if all(arg is not None for arg in (refresh_token, consumer_id, consumer_secret)):
+    if all(arg is not None for arg in (
+        refresh_token, consumer_id, consumer_secret)):
         # Use client credentials and refresh_token provided to Connected App by
         # Salesforce during OAuth process to get a new session/access_token
         data = {
@@ -109,7 +110,8 @@ def SalesforceLogin(
             if len(response_data) > 0:
                 response_data = response_data[0]
 
-            raise SalesforceAuthenticationFailed(response_data['errorCode'], response_data['message'])
+            raise SalesforceAuthenticationFailed(
+                response_data['errorCode'], response_data['message'])
 
         session_id = response_data.get('access_token')
         sf_instance = cleanseInstanceUrl(response_data.get('instance_url'))

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -13,12 +13,13 @@ except ImportError:
 import requests
 
 
-def _cleanseInstanceUrl(instance_url):
+def cleanseInstanceUrl(instance_url):
+    """Remove some common/likely noise from an instance url"""
     return (instance_url
-                   .replace('http://', '')
-                   .replace('https://', '')
-                   .split('/')[0]
-                   .replace('-api', ''))
+            .replace('http://', '')
+            .replace('https://', '')
+            .split('/')[0]
+            .replace('-api', ''))
 
 # pylint: disable=invalid-name,too-many-arguments,too-many-locals
 def SalesforceLogin(
@@ -73,10 +74,10 @@ def SalesforceLogin(
         # Use client credentials and refresh_token provided to Connected App by
         # Salesforce during OAuth process to get a new session/access_token
         data = {
-           'grant_type': 'refresh_token',
-           'client_id' : client_id,
-           'client_secret' : client_secret,
-           'refresh_token': refresh_token
+            'grant_type': 'refresh_token',
+            'client_id' : client_id,
+            'client_secret' : client_secret,
+            'refresh_token': refresh_token
         }
         headers = {
             'content-type': 'application/x-www-form-urlencoded'
@@ -91,15 +92,15 @@ def SalesforceLogin(
         if response.status_code != 200:
             # Something's gone wrong :(
 
-            # TODO: Could there be a case where this isn't a list? Or the error is
-            # not always in the first element? Not sure.
+            # TODO: Could there be a case where this isn't a list? Or the error
+            # is not always in the first element? Not sure.
             if len(response_data) > 0:
-                repsonse_data = response_data[0]
+                response_data = response_data[0]
 
             raise SalesforceAuthenticationFailed(response_data['errorCode'], response_data['message'])
 
         session_id = response_data.get('access_token')
-        sf_instance = _cleanseInstanceUrl(response_data.get('instance_url'))
+        sf_instance = cleanseInstanceUrl(response_data.get('instance_url'))
 
         return session_id, sf_instance
 
@@ -200,7 +201,7 @@ def SalesforceLogin(
     server_url = getUniqueElementValueFromXmlString(
         response.content, 'serverUrl')
 
-    sf_instance = _cleanseInstanceUrl(server_url)
+    sf_instance = cleanseInstanceUrl(server_url)
 
     return session_id, sf_instance
 

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -102,8 +102,13 @@ def SalesforceLogin(
 
         response_data = response.json()
 
+        print response
+        print response.text
+        print response.status_code
+
         if response.status_code != 200:
             # Something's gone wrong :(
+
 
             # TODO: Could there be a case where this isn't a list? Or the error
             # is not always in the first element? Not sure.

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -83,7 +83,7 @@ def SalesforceLogin(
     # Let's see if this flow is appropriate first as it's quite different
     # than the rest of the flows
     if all(arg is not None for arg in (
-        refresh_token, consumer_id, consumer_secret)):
+            refresh_token, consumer_id, consumer_secret)):
         # Use client credentials and refresh_token provided to Connected App by
         # Salesforce during OAuth process to get a new session/access_token
         data = {

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -28,7 +28,7 @@ def cleanseInstanceUrl(instance_url):
 # pylint: disable=invalid-name,too-many-arguments,too-many-locals
 def SalesforceLogin(
         username=None, password=None, security_token=None,
-        refresh_token=None, client_id=None, client_secret=None,
+        refresh_token=None, consumer_id=None, consumer_secret=None,
         organizationId=None, sandbox=False, sf_version=DEFAULT_API_VERSION,
         proxies=None, session=None, client_id=None):
     """Return a tuple of `(session_id, sf_instance)` where `session_id` is the
@@ -46,9 +46,9 @@ def SalesforceLogin(
 
     * refresh_token -- the refresh token provided to the Connected App (used in
         some OAuth schemes)
-    * client_id -- the client ID for the Connected App that was granted user's
+    * consumer_id -- the consumer ID for the Connected App that was granted user's
         refresh token
-    * client_secret -- the client secret for the Connected App that was granted the
+    * consumer_secret -- the consumer secret for the Connected App that was granted the
         user's refresh token.
 
 
@@ -82,13 +82,13 @@ def SalesforceLogin(
 
     # Let's see if this flow is appropriate first as it's quite different
     # than the rest of the flows
-    if all(arg is not None for arg in (refresh_token, client_id, client_secret)):
+    if all(arg is not None for arg in (refresh_token, consumer_id, consumer_secret)):
         # Use client credentials and refresh_token provided to Connected App by
         # Salesforce during OAuth process to get a new session/access_token
         data = {
             'grant_type': 'refresh_token',
-            'client_id' : client_id,
-            'client_secret' : client_secret,
+            'client_id' : consumer_id,
+            'client_secret' : consumer_secret,
             'refresh_token': refresh_token
         }
         headers = {

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -102,10 +102,6 @@ def SalesforceLogin(
 
         response_data = response.json()
 
-        print response
-        print response.text
-        print response.status_code
-
         if response.status_code != 200:
             # Something's gone wrong :(
 

--- a/simple_salesforce/tests/__init__.py
+++ b/simple_salesforce/tests/__init__.py
@@ -45,3 +45,7 @@ LOGIN_RESPONSE_SUCCESS = """<?xml version="1.0" encoding="UTF-8"?>
    </soapenv:Body>
 </soapenv:Envelope>
 """ % (METADATA_URL, SERVER_URL, SESSION_ID)
+
+
+REFRESH_TOKEN_RESPONSE_SUCCESS = """'{"access_token":"%s","signature":"xxxxxxxxxuOelk8emXZqI4KDeIF2HvKHGaQ=","scope":"refresh_token full","instance_url":"%s","id":"https://login.salesforce.com/id/00D36000000kxxxxxx/005360000024xxxxxx","token_type":"Bearer","issued_at":"1471024753853"}'
+""" % (SESSION_ID, SERVER_URL)

--- a/simple_salesforce/tests/__init__.py
+++ b/simple_salesforce/tests/__init__.py
@@ -46,4 +46,5 @@ LOGIN_RESPONSE_SUCCESS = """<?xml version="1.0" encoding="UTF-8"?>
 </soapenv:Envelope>
 """ % (METADATA_URL, SERVER_URL, SESSION_ID)
 
-REFRESH_TOKEN_RESPONSE_SUCCESS = {"access_token":SESSION_ID, "signature":"xxxxxxxxxuOelk8emXZqI4KDeIF2HvKHGaQ=", "scope":"refresh_token full", "instance_url":SERVER_URL, "id":"https://login.salesforce.com/id/00D36000000kxxxxxx/005360000024xxxxxx", "token_type":"Bearer", "issued_at":"1471024753853"}
+REFRESH_TOKEN_RESPONSE_SUCCESS_JSON = {"access_token":SESSION_ID, "signature":"xxxxxxxxxuOelk8emXZqI4KDeIF2HvKHGaQ=", "scope":"refresh_token full", "instance_url":SERVER_URL, "id":"https://login.salesforce.com/id/00D36000000kxxxxxx/005360000024xxxxxx", "token_type":"Bearer", "issued_at":"1471024753853"}
+REFRESH_TOKEN_RESPONSE_SUCCESS_STRING = """{"access_token":"%s", "signature":"xxxxxxxxxuOelk8emXZqI4KDeIF2HvKHGaQ=", "scope":"refresh_token full", "instance_url":"%s", "id":"https://login.salesforce.com/id/00D36000000kxxxxxx/005360000024xxxxxx", "token_type":"Bearer", "issued_at":"1471024753853"}""" % (SESSION_ID, SERVER_URL)

--- a/simple_salesforce/tests/__init__.py
+++ b/simple_salesforce/tests/__init__.py
@@ -46,6 +46,4 @@ LOGIN_RESPONSE_SUCCESS = """<?xml version="1.0" encoding="UTF-8"?>
 </soapenv:Envelope>
 """ % (METADATA_URL, SERVER_URL, SESSION_ID)
 
-
-REFRESH_TOKEN_RESPONSE_SUCCESS = """'{"access_token":"%s","signature":"xxxxxxxxxuOelk8emXZqI4KDeIF2HvKHGaQ=","scope":"refresh_token full","instance_url":"%s","id":"https://login.salesforce.com/id/00D36000000kxxxxxx/005360000024xxxxxx","token_type":"Bearer","issued_at":"1471024753853"}'
-""" % (SESSION_ID, SERVER_URL)
+REFRESH_TOKEN_RESPONSE_SUCCESS = {"access_token":SESSION_ID,"signature":"xxxxxxxxxuOelk8emXZqI4KDeIF2HvKHGaQ=","scope":"refresh_token full","instance_url":SERVER_URL,"id":"https://login.salesforce.com/id/00D36000000kxxxxxx/005360000024xxxxxx","token_type":"Bearer","issued_at":"1471024753853"}

--- a/simple_salesforce/tests/__init__.py
+++ b/simple_salesforce/tests/__init__.py
@@ -46,4 +46,4 @@ LOGIN_RESPONSE_SUCCESS = """<?xml version="1.0" encoding="UTF-8"?>
 </soapenv:Envelope>
 """ % (METADATA_URL, SERVER_URL, SESSION_ID)
 
-REFRESH_TOKEN_RESPONSE_SUCCESS = {"access_token":SESSION_ID,"signature":"xxxxxxxxxuOelk8emXZqI4KDeIF2HvKHGaQ=","scope":"refresh_token full","instance_url":SERVER_URL,"id":"https://login.salesforce.com/id/00D36000000kxxxxxx/005360000024xxxxxx","token_type":"Bearer","issued_at":"1471024753853"}
+REFRESH_TOKEN_RESPONSE_SUCCESS = {"access_token":SESSION_ID, "signature":"xxxxxxxxxuOelk8emXZqI4KDeIF2HvKHGaQ=", "scope":"refresh_token full", "instance_url":SERVER_URL, "id":"https://login.salesforce.com/id/00D36000000kxxxxxx/005360000024xxxxxx", "token_type":"Bearer", "issued_at":"1471024753853"}

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -72,7 +72,8 @@ class TestSalesforceLogin(unittest.TestCase):
             responses.POST,
             re.compile(r'^https://.*$'),
             json=tests.REFRESH_TOKEN_RESPONSE_SUCCESS,
-            status=http.OK
+            content_type='application/json',
+            status=200
         )
 
         session_id, sf_instance = SalesforceLogin(

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -71,7 +71,8 @@ class TestSalesforceLogin(unittest.TestCase):
         responses.add(
             responses.POST,
             re.compile(r'^https://.*$'),
-            json=tests.REFRESH_TOKEN_RESPONSE_SUCCESS,
+            body=tests.REFRESH_TOKEN_RESPONSE_SUCCESS_STRING,
+            # json=tests.REFRESH_TOKEN_RESPONSE_SUCCESS_JSON,
             content_type='application/json',
             status=200
         )

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -71,7 +71,7 @@ class TestSalesforceLogin(unittest.TestCase):
         responses.add(
             responses.POST,
             re.compile(r'^https://.*$'),
-            body=tests.REFRESH_TOKEN_RESPONSE_SUCCESS,
+            json=tests.REFRESH_TOKEN_RESPONSE_SUCCESS,
             status=http.OK
         )
 
@@ -81,7 +81,7 @@ class TestSalesforceLogin(unittest.TestCase):
             consumer_secret='MY_CONNECTED_APP_SECRET')
 
         self.assertEqual(session_id, tests.SESSION_ID)
-        self.assertEqual(instance, urlparse(tests.SERVER_URL).netloc)
+        self.assertEqual(sf_instance, urlparse(tests.SERVER_URL).netloc)
 
 
 

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -64,6 +64,27 @@ class TestSalesforceLogin(unittest.TestCase):
         self.assertEqual(session_id, tests.SESSION_ID)
         self.assertEqual(instance, urlparse(tests.SERVER_URL).netloc)
 
+
+    @responses.activate
+    def test_refresh_token_success(self):
+        """Test refresh_token success"""
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://.*$'),
+            body=tests.REFRESH_TOKEN_RESPONSE_SUCCESS,
+            status=http.OK
+        )
+
+        session_id, sf_instance = SalesforceLogin(
+            refresh_token='REFRESH_TOKEN_PROVIDED_DURING_A_PRIOR_AUTH',
+            consumer_id='MY_CONNECTED_APP_ID',
+            consumer_secret='MY_CONNECTED_APP_SECRET')
+
+        self.assertEqual(session_id, tests.SESSION_ID)
+        self.assertEqual(instance, urlparse(tests.SERVER_URL).netloc)
+
+
+
     def test_failure(self):
         """Test A Failed Login Response"""
         return_mock = Mock()


### PR DESCRIPTION
`simple-salesforce` seems like the most vibrant of the python Salesforce "SDK" modules, but it doesn't seem to inherently support the refreshing of access tokens when a Connected App (or perhaps other flow) was provided a `refresh_token` for this very purpose. I'd written my own wrapper class around `simple-salesforce` to accomplish this, but seemed like others would have this issue/problem as well so thought I should contribute. Salesforce's documentation is all over the place, but here's a decent, succinct example that illustrates what I'm adding to the `simple-salesforce` internals here: https://help.salesforce.com/apex/HTViewHelpDoc?id=remoteaccess_oauth_refresh_token_flow.htm&language=en

I tried to add/update decent comments and update the README, but feel free to change any formatting that I screwed up or provide any feedback you'd like me to incorporate.

Perhaps adding a "access_token_refreshed" callback that can be passed in by the user and executed when a token refresh is required and happens (successfully) would be a nice feature down the line, but starting with this.
