### PR TITLE
Allow custom HTTP headers when calling the update() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist/
 .tox/
 tags
 .env/
+.tags
+.tags_sorted_by_file

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -11,10 +11,10 @@ import requests
 import json
 
 try:
-    from urlparse import urlparse
+    from urlparse import urlparse, urljoin
 except ImportError:
     # Python 3+
-    from urllib.parse import urlparse
+    from urllib.parse import urlparse, urljoin
 from simple_salesforce.login import SalesforceLogin
 from simple_salesforce.util import date_to_iso8601, SalesforceError
 
@@ -513,7 +513,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         result = self._call_salesforce(
-            'GET', self.base_url + 'describe', headers=headers
+            method='GET', url=urljoin(self.base_url, 'describe'),
+            headers=headers
         )
         return result.json(object_pairs_hook=OrderedDict)
 
@@ -529,9 +530,12 @@ class SFType(object):
         * record_id -- the Id of the SObject to get
         * headers -- a dict with additional request headers.
         """
+        custom_url_part = 'describe/layouts/{record_id}'.format(
+            record_id=record_id
+        )
         result = self._call_salesforce(
-            'GET',
-            self.base_url + 'describe/layouts/' + record_id,
+            method='GET',
+            url=urljoin(self.base_url, custom_url_part),
             headers=headers
         )
         return result.json(object_pairs_hook=OrderedDict)
@@ -546,7 +550,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         result = self._call_salesforce(
-            'GET', self.base_url + record_id, headers=headers
+            method='GET', url=urljoin(self.base_url, record_id),
+            headers=headers
         )
         return result.json(object_pairs_hook=OrderedDict)
 
@@ -564,10 +569,14 @@ class SFType(object):
         * custom_id - the External ID value of the SObject to get
         * headers -- a dict with additional request headers.
         """
-        custom_url = self.base_url + '{custom_id_field}/{custom_id}'.format(
-            custom_id_field=custom_id_field, custom_id=custom_id
+        custom_url = urljoin(
+            self.base_url, '{custom_id_field}/{custom_id}'.format(
+                custom_id_field=custom_id_field, custom_id=custom_id
+            )
         )
-        result = self._call_salesforce('GET', custom_url, headers=headers)
+        result = self._call_salesforce(
+            method='GET', url=custom_url, headers=headers
+        )
         return result.json(object_pairs_hook=OrderedDict)
 
     def create(self, data, headers=None):
@@ -582,8 +591,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         result = self._call_salesforce(
-            'POST', self.base_url, data=json.dumps(data),
-            headers=headers
+            method='POST', url=self.base_url,
+            data=json.dumps(data), headers=headers
         )
         return result.json(object_pairs_hook=OrderedDict)
 
@@ -606,8 +615,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         result = self._call_salesforce(
-            'PATCH', self.base_url + record_id, data=json.dumps(data),
-            headers=headers
+            method='PATCH', url=urljoin(self.base_url, record_id),
+            data=json.dumps(data), headers=headers
         )
         return self._raw_response(result, raw_response)
 
@@ -629,8 +638,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         result = self._call_salesforce(
-            'PATCH', self.base_url + record_id, data=json.dumps(data),
-            headers=headers
+            method='PATCH', url=urljoin(self.base_url, record_id),
+            data=json.dumps(data), headers=headers
         )
         return self._raw_response(result, raw_response)
 
@@ -650,7 +659,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         result = self._call_salesforce(
-            'DELETE', self.base_url + record_id, headers=headers
+            method='DELETE', url=urljoin(self.base_url, record_id),
+            headers=headers
         )
         return self._raw_response(result, raw_response)
 
@@ -666,10 +676,12 @@ class SFType(object):
         * end -- end datetime object
         * headers -- a dict with additional request headers.
         """
-        url = self.base_url + 'deleted/?start={start}&end={end}'.format(
-            start=date_to_iso8601(start), end=date_to_iso8601(end)
+        url = urljoin(
+            self.base_url, 'deleted/?start={start}&end={end}'.format(
+                start=date_to_iso8601(start), end=date_to_iso8601(end)
+            )
         )
-        result = self._call_salesforce('GET', url, headers=headers)
+        result = self._call_salesforce(method='GET', url=url, headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
     def updated(self, start, end, headers=None):
@@ -685,10 +697,12 @@ class SFType(object):
         * end -- end datetime object
         * headers -- a dict with additional request headers.
         """
-        url = self.base_url + 'updated/?start={start}&end={end}'.format(
-            start=date_to_iso8601(start), end=date_to_iso8601(end)
+        url = urljoin(
+            self.base_url, 'updated/?start={start}&end={end}'.format(
+                start=date_to_iso8601(start), end=date_to_iso8601(end)
+            )
         )
-        result = self._call_salesforce('GET', url, headers=headers)
+        result = self._call_salesforce(method='GET', url=url, headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
     def _call_salesforce(self, method, url, **kwargs):

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -493,43 +493,61 @@ class SFType(object):
                                      object_name=object_name,
                                      sf_version=sf_version))
 
-    def metadata(self):
+    def metadata(self, headers=None):
         """Returns the result of a GET to `.../{object_name}/` as a dict
         decoded from the JSON payload returned by Salesforce.
+
+        Arguments:
+
+        * headers -- a dict with additional request headers.
         """
-        result = self._call_salesforce('GET', self.base_url)
+        result = self._call_salesforce('GET', self.base_url, headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
-    def describe(self):
+    def describe(self, headers=None):
         """Returns the result of a GET to `.../{object_name}/describe` as a
         dict decoded from the JSON payload returned by Salesforce.
+
+        Arguments:
+
+        * headers -- a dict with additional request headers.
         """
-        result = self._call_salesforce('GET', self.base_url + 'describe')
+        result = self._call_salesforce(
+            'GET', self.base_url + 'describe', headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
-    def describe_layout(self, record_id):
+    def describe_layout(self, record_id, headers=None):
         """Returns the layout of the object
 
         Returns the result of a GET to
         `.../{object_name}/describe/layouts/<recordid>` as a dict decoded from
         the JSON payload returned by Salesforce.
+
+        Arguments:
+
+        * record_id -- the Id of the SObject to get
+        * headers -- a dict with additional request headers.
         """
         result = self._call_salesforce(
-            'GET', self.base_url + 'describe/layouts/' + record_id)
+            'GET',
+            self.base_url + 'describe/layouts/' + record_id,
+            headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
-    def get(self, record_id):
+    def get(self, record_id, headers=None):
         """Returns the result of a GET to `.../{object_name}/{record_id}` as a
         dict decoded from the JSON payload returned by Salesforce.
 
         Arguments:
 
         * record_id -- the Id of the SObject to get
+        * headers -- a dict with additional request headers.
         """
-        result = self._call_salesforce('GET', self.base_url + record_id)
+        result = self._call_salesforce(
+            'GET', self.base_url + record_id, headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
-    def get_by_custom_id(self, custom_id_field, custom_id):
+    def get_by_custom_id(self, custom_id_field, custom_id, headers=None):
         """Return an ``SFType`` by custom ID
 
         Returns the result of a GET to
@@ -541,13 +559,14 @@ class SFType(object):
         * custom_id_field -- the API name of a custom field that was defined
                              as an External ID
         * custom_id - the External ID value of the SObject to get
+        * headers -- a dict with additional request headers.
         """
         custom_url = self.base_url + '{custom_id_field}/{custom_id}'.format(
             custom_id_field=custom_id_field, custom_id=custom_id)
-        result = self._call_salesforce('GET', custom_url)
+        result = self._call_salesforce('GET', custom_url, headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
-    def create(self, data):
+    def create(self, data, headers=None):
         """Creates a new SObject using a POST to `.../{object_name}/`.
 
         Returns a dict decoded from the JSON payload returned by Salesforce.
@@ -556,12 +575,14 @@ class SFType(object):
 
         * data -- a dict of the data to create the SObject from. It will be
                   JSON-encoded before being transmitted.
+        * headers -- a dict with additional request headers.
         """
-        result = self._call_salesforce('POST', self.base_url,
-                                       data=json.dumps(data))
+        result = self._call_salesforce(
+            'POST', self.base_url, data=json.dumps(data),
+            headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
-    def upsert(self, record_id, data, raw_response=False):
+    def upsert(self, record_id, data, raw_response=False, headers=None):
         """Creates or updates an SObject using a PATCH to
         `.../{object_name}/{record_id}`.
 
@@ -577,12 +598,14 @@ class SFType(object):
                   will be JSON-encoded before being transmitted.
         * raw_response -- a boolean indicating whether to return the response
                           directly, instead of the status code.
+        * headers -- a dict with additional request headers.
         """
-        result = self._call_salesforce('PATCH', self.base_url + record_id,
-                                       data=json.dumps(data))
+        result = self._call_salesforce(
+            'PATCH', self.base_url + record_id, data=json.dumps(data),
+            headers=headers)
         return self._raw_response(result, raw_response)
 
-    def update(self, record_id, data, raw_response=False, **kwargs):
+    def update(self, record_id, data, raw_response=False, headers=None):
         """Updates an SObject using a PATCH to
         `.../{object_name}/{record_id}`.
 
@@ -597,12 +620,14 @@ class SFType(object):
                   JSON-encoded before being transmitted.
         * raw_response -- a boolean indicating whether to return the response
                           directly, instead of the status code.
+        * headers -- a dict with additional request headers.
         """
-        result = self._call_salesforce('PATCH', self.base_url + record_id,
-                                       data=json.dumps(data), **kwargs)
+        result = self._call_salesforce(
+            'PATCH', self.base_url + record_id, data=json.dumps(data),
+            headers=headers)
         return self._raw_response(result, raw_response)
 
-    def delete(self, record_id, raw_response=False):
+    def delete(self, record_id, raw_response=False, headers=None):
         """Deletes an SObject using a DELETE to
         `.../{object_name}/{record_id}`.
 
@@ -615,11 +640,13 @@ class SFType(object):
         * record_id -- the Id of the SObject to delete
         * raw_response -- a boolean indicating whether to return the response
                           directly, instead of the status code.
+        * headers -- a dict with additional request headers.
         """
-        result = self._call_salesforce('DELETE', self.base_url + record_id)
+        result = self._call_salesforce(
+            'DELETE', self.base_url + record_id, headers=headers)
         return self._raw_response(result, raw_response)
 
-    def deleted(self, start, end):
+    def deleted(self, start, end, headers=None):
         # pylint: disable=line-too-long
         """Gets a list of deleted records
 
@@ -629,13 +656,14 @@ class SFType(object):
 
         * start -- start datetime object
         * end -- end datetime object
+        * headers -- a dict with additional request headers.
         """
         url = self.base_url + 'deleted/?start={start}&end={end}'.format(
             start=date_to_iso8601(start), end=date_to_iso8601(end))
-        result = self._call_salesforce('GET', url)
+        result = self._call_salesforce('GET', url, headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
-    def updated(self, start, end):
+    def updated(self, start, end, headers=None):
         # pylint: disable=line-too-long
         """Gets a list of updated records
 
@@ -646,10 +674,11 @@ class SFType(object):
 
         * start -- start datetime object
         * end -- end datetime object
+        * headers -- a dict with additional request headers.
         """
         url = self.base_url + 'updated/?start={start}&end={end}'.format(
             start=date_to_iso8601(start), end=date_to_iso8601(end))
-        result = self._call_salesforce('GET', url)
+        result = self._call_salesforce('GET', url, headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
     def _call_salesforce(self, method, url, **kwargs):
@@ -662,7 +691,8 @@ class SFType(object):
             'Authorization': 'Bearer ' + self.session_id,
             'X-PrettyPrint': '1'
         }
-        headers.update(kwargs.pop('headers', dict()))
+        additional_headers = kwargs.pop('headers', dict())
+        headers.update(additional_headers or dict())
         result = self.session.request(method, url, headers=headers, **kwargs)
 
         if result.status_code >= 300:

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -513,7 +513,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         result = self._call_salesforce(
-            'GET', self.base_url + 'describe', headers=headers)
+            'GET', self.base_url + 'describe', headers=headers
+        )
         return result.json(object_pairs_hook=OrderedDict)
 
     def describe_layout(self, record_id, headers=None):
@@ -531,7 +532,8 @@ class SFType(object):
         result = self._call_salesforce(
             'GET',
             self.base_url + 'describe/layouts/' + record_id,
-            headers=headers)
+            headers=headers
+        )
         return result.json(object_pairs_hook=OrderedDict)
 
     def get(self, record_id, headers=None):
@@ -544,7 +546,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         result = self._call_salesforce(
-            'GET', self.base_url + record_id, headers=headers)
+            'GET', self.base_url + record_id, headers=headers
+        )
         return result.json(object_pairs_hook=OrderedDict)
 
     def get_by_custom_id(self, custom_id_field, custom_id, headers=None):
@@ -562,7 +565,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         custom_url = self.base_url + '{custom_id_field}/{custom_id}'.format(
-            custom_id_field=custom_id_field, custom_id=custom_id)
+            custom_id_field=custom_id_field, custom_id=custom_id
+        )
         result = self._call_salesforce('GET', custom_url, headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
@@ -579,7 +583,8 @@ class SFType(object):
         """
         result = self._call_salesforce(
             'POST', self.base_url, data=json.dumps(data),
-            headers=headers)
+            headers=headers
+        )
         return result.json(object_pairs_hook=OrderedDict)
 
     def upsert(self, record_id, data, raw_response=False, headers=None):
@@ -602,7 +607,8 @@ class SFType(object):
         """
         result = self._call_salesforce(
             'PATCH', self.base_url + record_id, data=json.dumps(data),
-            headers=headers)
+            headers=headers
+        )
         return self._raw_response(result, raw_response)
 
     def update(self, record_id, data, raw_response=False, headers=None):
@@ -624,7 +630,8 @@ class SFType(object):
         """
         result = self._call_salesforce(
             'PATCH', self.base_url + record_id, data=json.dumps(data),
-            headers=headers)
+            headers=headers
+        )
         return self._raw_response(result, raw_response)
 
     def delete(self, record_id, raw_response=False, headers=None):
@@ -643,7 +650,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         result = self._call_salesforce(
-            'DELETE', self.base_url + record_id, headers=headers)
+            'DELETE', self.base_url + record_id, headers=headers
+        )
         return self._raw_response(result, raw_response)
 
     def deleted(self, start, end, headers=None):
@@ -659,7 +667,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         url = self.base_url + 'deleted/?start={start}&end={end}'.format(
-            start=date_to_iso8601(start), end=date_to_iso8601(end))
+            start=date_to_iso8601(start), end=date_to_iso8601(end)
+        )
         result = self._call_salesforce('GET', url, headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 
@@ -677,7 +686,8 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         url = self.base_url + 'updated/?start={start}&end={end}'.format(
-            start=date_to_iso8601(start), end=date_to_iso8601(end))
+            start=date_to_iso8601(start), end=date_to_iso8601(end)
+        )
         result = self._call_salesforce('GET', url, headers=headers)
         return result.json(object_pairs_hook=OrderedDict)
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -582,7 +582,7 @@ class SFType(object):
                                        data=json.dumps(data))
         return self._raw_response(result, raw_response)
 
-    def update(self, record_id, data, raw_response=False):
+    def update(self, record_id, data, raw_response=False, **kwargs):
         """Updates an SObject using a PATCH to
         `.../{object_name}/{record_id}`.
 
@@ -599,7 +599,7 @@ class SFType(object):
                           directly, instead of the status code.
         """
         result = self._call_salesforce('PATCH', self.base_url + record_id,
-                                       data=json.dumps(data))
+                                       data=json.dumps(data), **kwargs)
         return self._raw_response(result, raw_response)
 
     def delete(self, record_id, raw_response=False):
@@ -662,6 +662,7 @@ class SFType(object):
             'Authorization': 'Bearer ' + self.session_id,
             'X-PrettyPrint': '1'
         }
+        headers.update(kwargs.pop('headers', dict()))
         result = self.session.request(method, url, headers=headers, **kwargs)
 
         if result.status_code >= 300:

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -91,7 +91,7 @@ class TestSFType(unittest.TestCase):
         """Ensure custom headers are used for describe requests"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/describe$'),
             body='{}',
             status=http.OK
         )
@@ -111,7 +111,7 @@ class TestSFType(unittest.TestCase):
         """Ensure describe requests without additional headers"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/describe$'),
             body='{}',
             status=http.OK
         )
@@ -125,7 +125,7 @@ class TestSFType(unittest.TestCase):
         """Ensure custom headers are used for describe_layout requests"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/describe/layouts/444$'),
             body='{}',
             status=http.OK
         )
@@ -146,7 +146,7 @@ class TestSFType(unittest.TestCase):
         """Ensure describe_layout requests without additional headers"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/describe/layouts/444$'),
             body='{}',
             status=http.OK
         )
@@ -160,7 +160,7 @@ class TestSFType(unittest.TestCase):
         """Ensure custom headers are used for get requests"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/444$'),
             body='{}',
             status=http.OK
         )
@@ -181,7 +181,7 @@ class TestSFType(unittest.TestCase):
         """Ensure get requests without additional headers"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/444$'),
             body='{}',
             status=http.OK
         )
@@ -195,7 +195,7 @@ class TestSFType(unittest.TestCase):
         """Ensure custom headers are used for get_by_custom_id requests"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/some-field/444$'),
             body='{}',
             status=http.OK
         )
@@ -217,7 +217,7 @@ class TestSFType(unittest.TestCase):
         """Ensure get_by_custom_id requests without additional headers"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/some-field/444$'),
             body='{}',
             status=http.OK
         )
@@ -235,7 +235,7 @@ class TestSFType(unittest.TestCase):
         """Ensure custom headers are used for create requests"""
         responses.add(
             responses.POST,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/$'),
             body='{}',
             status=http.OK
         )
@@ -256,7 +256,7 @@ class TestSFType(unittest.TestCase):
         """Ensure create requests without additional headers"""
         responses.add(
             responses.POST,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/$'),
             body='{}',
             status=http.OK
         )
@@ -271,7 +271,7 @@ class TestSFType(unittest.TestCase):
         """Ensure custom headers are used for updates"""
         responses.add(
             responses.PATCH,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/some-case-id$'),
             body='{}',
             status=http.OK
         )
@@ -293,7 +293,7 @@ class TestSFType(unittest.TestCase):
         """Ensure updates work without custom headers"""
         responses.add(
             responses.PATCH,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/some-case-id$'),
             body='{}',
             status=http.OK
         )
@@ -311,7 +311,7 @@ class TestSFType(unittest.TestCase):
         """Ensure custom headers are used for upserts"""
         responses.add(
             responses.PATCH,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/some-case-id$'),
             body='{}',
             status=http.OK
         )
@@ -333,7 +333,7 @@ class TestSFType(unittest.TestCase):
         """Ensure upserts work without custom headers"""
         responses.add(
             responses.PATCH,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/some-case-id$'),
             body='{}',
             status=http.OK
         )
@@ -351,7 +351,7 @@ class TestSFType(unittest.TestCase):
         """Ensure custom headers are used for deletes"""
         responses.add(
             responses.DELETE,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/some-case-id$'),
             body='{}',
             status=http.OK
         )
@@ -372,7 +372,7 @@ class TestSFType(unittest.TestCase):
         """Ensure deletes work without custom headers"""
         responses.add(
             responses.DELETE,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/some-case-id$'),
             body='{}',
             status=http.OK
         )
@@ -387,7 +387,7 @@ class TestSFType(unittest.TestCase):
         """Ensure custom headers are used for deleted"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/deleted/\?start=.+&end=.+$'),
             body='{}',
             status=http.OK
         )
@@ -408,7 +408,7 @@ class TestSFType(unittest.TestCase):
         """Ensure deleted works without custom headers"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/deleted/\?start=.+&end=.+$'),
             body='{}',
             status=http.OK
         )
@@ -424,7 +424,7 @@ class TestSFType(unittest.TestCase):
         """Ensure custom headers are used for updated"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/updated/\?start=.+&end=.+$'),
             body='{}',
             status=http.OK
         )
@@ -445,7 +445,7 @@ class TestSFType(unittest.TestCase):
         """Ensure updated works without custom headers"""
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*$'),
+            re.compile(r'^https://.*/Case/updated/\?start=.+&end=.+$'),
             body='{}',
             status=http.OK
         )

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -1,6 +1,7 @@
 """Tests for api.py"""
 
 import re
+from datetime import datetime
 try:
     # Python 2.6
     import unittest2 as unittest
@@ -34,12 +35,236 @@ from simple_salesforce.api import (
 )
 
 
+def _create_sf_type():
+    """Creates SFType instances"""
+    return SFType(
+        object_name='Case',
+        session_id='5',
+        sf_instance='test.salesforce.com',
+        session=requests.Session()
+    )
+
+
 class TestSFType(unittest.TestCase):
     """Tests for the SFType instance"""
     def setUp(self):
         request_patcher = patch('simple_salesforce.api.requests')
         self.mockrequest = request_patcher.start()
         self.addCleanup(request_patcher.stop)
+
+    @responses.activate
+    def test_metadata_with_additional_request_headers(self):
+        """Ensure custom headers are used for metadata requests"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.metadata(
+            headers={'Sforce-Auto-Assign': 'FALSE'}
+        )
+
+        request_headers = responses.calls[0].request.headers
+        additional_request_header = request_headers['Sforce-Auto-Assign']
+        self.assertEqual(additional_request_header, 'FALSE')
+        self.assertEqual(result, {})
+
+    @responses.activate
+    def test_metadata_without_additional_request_headers(self):
+        """Ensure metadata requests without additional headers"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+
+        self.assertEqual(sf_type.metadata(), {})
+
+    @responses.activate
+    def test_describe_with_additional_request_headers(self):
+        """Ensure custom headers are used for describe requests"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.describe(
+            headers={'Sforce-Auto-Assign': 'FALSE'}
+        )
+
+        request_headers = responses.calls[0].request.headers
+        additional_request_header = request_headers['Sforce-Auto-Assign']
+        self.assertEqual(additional_request_header, 'FALSE')
+        self.assertEqual(result, {})
+
+    @responses.activate
+    def test_describe_without_additional_request_headers(self):
+        """Ensure describe requests without additional headers"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+
+        self.assertEqual(sf_type.describe(), {})
+
+    @responses.activate
+    def test_describe_layout_with_additional_request_headers(self):
+        """Ensure custom headers are used for describe_layout requests"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.describe_layout(
+            record_id='444',
+            headers={'Sforce-Auto-Assign': 'FALSE'}
+        )
+
+        request_headers = responses.calls[0].request.headers
+        additional_request_header = request_headers['Sforce-Auto-Assign']
+        self.assertEqual(additional_request_header, 'FALSE')
+        self.assertEqual(result, {})
+
+    @responses.activate
+    def test_describe_layout_without_additional_request_headers(self):
+        """Ensure describe_layout requests without additional headers"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+
+        self.assertEqual(sf_type.describe_layout(record_id='444'), {})
+
+    @responses.activate
+    def test_get_with_additional_request_headers(self):
+        """Ensure custom headers are used for get requests"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.get(
+            record_id='444',
+            headers={'Sforce-Auto-Assign': 'FALSE'}
+        )
+
+        request_headers = responses.calls[0].request.headers
+        additional_request_header = request_headers['Sforce-Auto-Assign']
+        self.assertEqual(additional_request_header, 'FALSE')
+        self.assertEqual(result, {})
+
+    @responses.activate
+    def test_get_without_additional_request_headers(self):
+        """Ensure get requests without additional headers"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+
+        self.assertEqual(sf_type.get(record_id='444'), {})
+
+    @responses.activate
+    def test_get_by_custom_id_with_additional_request_headers(self):
+        """Ensure custom headers are used for get_by_custom_id requests"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.get_by_custom_id(
+            custom_id_field='some-field',
+            custom_id='444',
+            headers={'Sforce-Auto-Assign': 'FALSE'}
+        )
+
+        request_headers = responses.calls[0].request.headers
+        additional_request_header = request_headers['Sforce-Auto-Assign']
+        self.assertEqual(additional_request_header, 'FALSE')
+        self.assertEqual(result, {})
+
+    @responses.activate
+    def test_get_by_custom_id_without_additional_request_headers(self):
+        """Ensure get_by_custom_id requests without additional headers"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.get_by_custom_id(
+            custom_id_field='some-field',
+            custom_id='444'
+        )
+
+        self.assertEqual(result, {})
+
+    @responses.activate
+    def test_create_with_additional_request_headers(self):
+        """Ensure custom headers are used for create requests"""
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.create(
+            data={'some': 'data'},
+            headers={'Sforce-Auto-Assign': 'FALSE'}
+        )
+
+        request_headers = responses.calls[0].request.headers
+        additional_request_header = request_headers['Sforce-Auto-Assign']
+        self.assertEqual(additional_request_header, 'FALSE')
+        self.assertEqual(result, {})
+
+    @responses.activate
+    def test_create_without_additional_request_headers(self):
+        """Ensure create requests without additional headers"""
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.create(data={'some': 'data'})
+
+        self.assertEqual(result, {})
 
     @responses.activate
     def test_update_with_additional_request_headers(self):
@@ -51,13 +276,8 @@ class TestSFType(unittest.TestCase):
             status=http.OK
         )
 
-        sf_type = SFType(
-            object_name='Case',
-            session_id='5',
-            sf_instance='test.salesforce.com',
-            session=requests.Session()
-        )
-        update_result = sf_type.update(
+        sf_type = _create_sf_type()
+        result = sf_type.update(
             record_id='some-case-id',
             data={'some': 'data'},
             headers={'Sforce-Auto-Assign': 'FALSE'}
@@ -66,7 +286,7 @@ class TestSFType(unittest.TestCase):
         request_headers = responses.calls[0].request.headers
         additional_request_header = request_headers['Sforce-Auto-Assign']
         self.assertEqual(additional_request_header, 'FALSE')
-        self.assertEqual(update_result, http.OK)
+        self.assertEqual(result, http.OK)
 
     @responses.activate
     def test_update_without_additional_request_headers(self):
@@ -78,18 +298,163 @@ class TestSFType(unittest.TestCase):
             status=http.OK
         )
 
-        sf_type = SFType(
-            object_name='Case',
-            session_id='5',
-            sf_instance='test.salesforce.com',
-            session=requests.Session()
-        )
-        update_result = sf_type.update(
+        sf_type = _create_sf_type()
+        result = sf_type.update(
             record_id='some-case-id',
             data={'some': 'data'}
         )
 
-        self.assertEqual(update_result, http.OK)
+        self.assertEqual(result, http.OK)
+
+    @responses.activate
+    def test_upsert_with_additional_request_headers(self):
+        """Ensure custom headers are used for upserts"""
+        responses.add(
+            responses.PATCH,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.upsert(
+            record_id='some-case-id',
+            data={'some': 'data'},
+            headers={'Sforce-Auto-Assign': 'FALSE'}
+        )
+
+        request_headers = responses.calls[0].request.headers
+        additional_request_header = request_headers['Sforce-Auto-Assign']
+        self.assertEqual(additional_request_header, 'FALSE')
+        self.assertEqual(result, http.OK)
+
+    @responses.activate
+    def test_upsert_without_additional_request_headers(self):
+        """Ensure upserts work without custom headers"""
+        responses.add(
+            responses.PATCH,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.upsert(
+            record_id='some-case-id',
+            data={'some': 'data'}
+        )
+
+        self.assertEqual(result, http.OK)
+
+    @responses.activate
+    def test_delete_with_additional_request_headers(self):
+        """Ensure custom headers are used for deletes"""
+        responses.add(
+            responses.DELETE,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.delete(
+            record_id='some-case-id',
+            headers={'Sforce-Auto-Assign': 'FALSE'}
+        )
+
+        request_headers = responses.calls[0].request.headers
+        additional_request_header = request_headers['Sforce-Auto-Assign']
+        self.assertEqual(additional_request_header, 'FALSE')
+        self.assertEqual(result, http.OK)
+
+    @responses.activate
+    def test_delete_without_additional_request_headers(self):
+        """Ensure deletes work without custom headers"""
+        responses.add(
+            responses.DELETE,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.delete(record_id='some-case-id')
+
+        self.assertEqual(result, http.OK)
+
+    @responses.activate
+    def test_deleted_with_additional_request_headers(self):
+        """Ensure custom headers are used for deleted"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.deleted(
+            start=datetime.now(), end=datetime.now(),
+            headers={'Sforce-Auto-Assign': 'FALSE'}
+        )
+
+        request_headers = responses.calls[0].request.headers
+        additional_request_header = request_headers['Sforce-Auto-Assign']
+        self.assertEqual(additional_request_header, 'FALSE')
+        self.assertEqual(result, {})
+
+    @responses.activate
+    def test_deleted_without_additional_request_headers(self):
+        """Ensure deleted works without custom headers"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.deleted(
+            start=datetime.now(), end=datetime.now())
+
+        self.assertEqual(result, {})
+
+    @responses.activate
+    def test_updated_with_additional_request_headers(self):
+        """Ensure custom headers are used for updated"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.updated(
+            start=datetime.now(), end=datetime.now(),
+            headers={'Sforce-Auto-Assign': 'FALSE'}
+        )
+
+        request_headers = responses.calls[0].request.headers
+        additional_request_header = request_headers['Sforce-Auto-Assign']
+        self.assertEqual(additional_request_header, 'FALSE')
+        self.assertEqual(result, {})
+
+    @responses.activate
+    def test_updated_without_additional_request_headers(self):
+        """Ensure updated works without custom headers"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.updated(
+            start=datetime.now(), end=datetime.now())
+
+        self.assertEqual(result, {})
 
 
 class TestSalesforce(unittest.TestCase):

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -35,12 +35,16 @@ from simple_salesforce.api import (
 )
 
 
-def _create_sf_type():
+def _create_sf_type(
+    object_name='Case',
+    session_id='5',
+    sf_instance='my.salesforce.com'
+):
     """Creates SFType instances"""
     return SFType(
-        object_name='Case',
-        session_id='5',
-        sf_instance='test.salesforce.com',
+        object_name=object_name,
+        session_id=session_id,
+        sf_instance=sf_instance,
         session=requests.Session()
     )
 


### PR DESCRIPTION
**Same changes as in https://github.com/simple-salesforce/simple-salesforce/pull/104 but with tests.**

## Original Description

There are some cases where the user needs to pass a custom HTTP header when making a record update request. The situation I ran into was passing the custom "Sforce-Auto-Assign" header when updating a lead to prevent auto-assign rules from running:

https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/headers_autoassign.htm

This trivial library change allows the user to pass custom headers; for example, in the situation above:

    sf.Lead.update(lead_id, lead_updates, headers={'Sforce-Auto-Assign': 'FALSE'})