### PR TITLE
modify total size correctly

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -399,7 +399,6 @@ class Salesforce(object):
             else:
                 result = self.query_more(previous_result['nextRecordsUrl'],
                                          identifier_is_url=True, **kwargs)
-                result['totalSize'] += previous_result['totalSize']
                 # Include the new list of records with the previous list
                 previous_result['records'].extend(result['records'])
                 result['records'] = previous_result['records']


### PR DESCRIPTION
Result totalSize is more than actual total size when we need to retrieve the remaining SOQL query results.
I think we don't need to add totalSize each retrieving.
