### PR TITLE
Feature/bulk api

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,6 +230,60 @@ To retrieve a list of top level description of instance metadata, user:
       print x["label"]
 
 
+Using Bulk
+----------
+
+You can use this library to access Bulk API functions.
+
+Create new records:
+
+.. code-block:: python
+
+    data = [{'LastName':'Smith','Email':'example@example.com'}, {'LastName':'Jones','Email':'test@test.com'}]
+
+    sf.bulk.Contact.insert(data)
+
+Update existing records:
+
+.. code-block:: python
+
+    data = [{'Id': '0000000000AAAAA', 'Email': 'examplenew@example.com'}, {'Id': '0000000000BBBBB', 'Email': 'testnew@test.com'}]
+
+    sf.bulk.Contact.update(data)
+
+Upsert records:
+
+.. code-block:: python
+
+    data = [{'Id': '0000000000AAAAA', 'Email': 'examplenew2@example.com'}, {'Id': '', 'Email': 'foo@foo.com'}]
+
+    sf.bulk.Contact.upsert(data, 'Id')
+
+Query records:
+
+.. code-block:: python
+
+    query = 'SELECT Id, Name FROM Account LIMIT 10'
+
+    sf.bulk.Account.query(query)
+
+Delete records (soft deletion):
+
+.. code-block:: python
+
+    data = [{'Id': '0000000000AAAAA'}]
+
+    sf.bulk.Contact.delete(data)
+
+Hard deletion:
+
+.. code-block:: python
+
+    data = [{'Id': '0000000000BBBBB'}]
+
+    sf.bulk.Contact.hard_delete(data)
+
+
 Using Apex
 ----------
 

--- a/simple_salesforce/__init__.py
+++ b/simple_salesforce/__init__.py
@@ -5,7 +5,6 @@ from simple_salesforce.api import (
     Salesforce,
     SalesforceAPI,
     SFType,
-    SFBulkType,
     SFBulkHandler,
     SalesforceError,
     SalesforceMoreThanOneRecord,

--- a/simple_salesforce/__init__.py
+++ b/simple_salesforce/__init__.py
@@ -5,6 +5,8 @@ from simple_salesforce.api import (
     Salesforce,
     SalesforceAPI,
     SFType,
+    SFBulkType,
+    SFBulkHandler,
     SalesforceError,
     SalesforceMoreThanOneRecord,
     SalesforceExpiredSession,

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -785,9 +785,20 @@ class SFBulkType(object):
             'contentType': 'JSON'
         }
 
-        result = _call_salesforce(url=self.bulk_url, method='POST', session=self.session, headers=self.headers)
+        result = _call_salesforce(url=self.bulk_url, method='POST', session=self.session, headers=self.headers, data=json.dumps(payload))
         return result.json(object_pairs_hook=OrderedDict)
 
+    def _close_job(self, job_id):
+        """ Close a bulk job """
+
+        payload = {
+            'state': 'Closed'
+        }
+
+        url = self.bulk_url + '/' + job_id
+
+        result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=json.dumps(payload))
+        return result.json(object_pairs_hook=OrderedDict)
 
 
 class SalesforceAPI(Salesforce):

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -207,7 +207,7 @@ class Salesforce(object):
 
         if name == 'bulk':
             # Deal with bulk API functions
-            return SFBulkHandler(self.session_id, self.sf_instance, self.bulk_url, self.proxies, self.session)
+            return SFBulkHandler(self.session_id, self.bulk_url, self.proxies, self.session)
 
         return SFType(
             name, self.session_id, self.sf_instance, sf_version=self.sf_version,

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -776,10 +776,17 @@ class SFBulkType(object):
                          .format(instance=self.sf_instance,
                                  version=self.sf_version))
 
-    def _create_job_(self, operation, object_name):
+    def _create_job(self, operation, object_name):
         """ Create a bulk job """
 
+        payload = {
+            'operation': operation,
+            'object': object_name,
+            'contentType': 'JSON'
+        }
 
+        result = _call_salesforce(url=self.bulk_url, method='POST', session=self.session, headers=self.headers)
+        return result.json(object_pairs_hook=OrderedDict)
 
 
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -9,7 +9,6 @@ import logging
 import warnings
 import requests
 import json
-from time import sleep
 
 try:
     from urlparse import urlparse, urljoin
@@ -18,7 +17,7 @@ except ImportError:
     from urllib.parse import urlparse, urljoin
 from simple_salesforce.login import SalesforceLogin
 from simple_salesforce.util import date_to_iso8601, SalesforceError
-from simple_salesforce.bulk import SFBulkType, SFBulkHandler
+from simple_salesforce.bulk import SFBulkHandler, SFBulkType
 
 try:
     from collections import OrderedDict
@@ -206,11 +205,9 @@ class Salesforce(object):
         if name.startswith('__'):
             return super(Salesforce, self).__getattr__(name)
 
-        if name=='bulk':
-            """
-            Deal with bulk API functions
-            """
-             return SFBulkHandler(self.session_id, self.sf_instance, self.bulk_url, self.proxies, self.session)
+        if name == 'bulk':
+            # Deal with bulk API functions
+            return SFBulkHandler(self.session_id, self.sf_instance, self.bulk_url, self.proxies, self.session)
 
         return SFType(
             name, self.session_id, self.sf_instance, sf_version=self.sf_version,

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -207,7 +207,8 @@ class Salesforce(object):
 
         if name == 'bulk':
             # Deal with bulk API functions
-            return SFBulkHandler(self.session_id, self.bulk_url, self.proxies, self.session)
+            return SFBulkHandler(self.session_id, self.bulk_url, self.proxies,
+                                 self.session)
 
         return SFType(
             name, self.session_id, self.sf_instance, sf_version=self.sf_version,

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -329,7 +329,7 @@ class Salesforce(object):
         Arguments:
 
         * query -- the SOQL query to send to Salesforce, e.g.
-                   `SELECT Id FROM Lead WHERE Email = "waldo@somewhere.com"`
+                   SELECT Id FROM Lead WHERE Email = "waldo@somewhere.com"
         """
         url = self.base_url + 'query/'
         params = {'q': query}
@@ -385,7 +385,7 @@ class Salesforce(object):
         Arguments
 
         * query -- the SOQL query to send to Salesforce, e.g.
-                   `SELECT Id FROM Lead WHERE Email = "waldo@somewhere.com"`
+                   SELECT Id FROM Lead WHERE Email = "waldo@somewhere.com"
         """
 
         result = self.query(query, **kwargs)
@@ -738,6 +738,49 @@ class SFType(object):
         """Deprecated setter for self.session"""
         _warn_request_deprecation()
         self.session = session
+
+class SFBulkType(object):
+    """ Interface to Bulk/Async API functions"""
+
+    def __init__(
+                 self, object_name, session_id, sf_instance,
+                 sf_version=DEFAULT_API_VERSION, proxies=None, session=None):
+        """Initialize the instance with the given parameters.
+
+        Arguments:
+
+        * object_name -- the name of the type of SObject this represents,
+                         e.g. `Lead` or `Contact`
+        * session_id -- the session ID for authenticating to Salesforce
+        * sf_instance -- the domain of the instance of Salesforce to use
+        * sf_version -- the version of the Salesforce API to use
+        * proxies -- the optional map of scheme to proxy server
+        * session -- Custom requests session, created in calling code. This
+                     enables the use of requests Session features not otherwise
+                     exposed by simple_salesforce.
+        """
+        self.session_id = session_id
+        self.name = object_name
+        self.session = session or requests.Session()
+        # don't wipe out original proxies with None
+        if not session and proxies is not None:
+            self.session.proxies = proxies
+
+        self.headers = {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + self.session_id,
+            'X-PrettyPrint': '1'
+        }
+
+        self.bulk_url = ('https://{instance}/services/async/{version}/'
+                         .format(instance=self.sf_instance,
+                                 version=self.sf_version))
+
+    def _create_job_(self, operation, object_name):
+        """ Create a bulk job """
+
+
+
 
 
 class SalesforceAPI(Salesforce):

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -817,6 +817,20 @@ class SalesforceAPI(Salesforce):
                                             sandbox=sandbox,
                                             version=sf_version)
 
+def _call_salesforce(url, method, headers, **kwargs):
+    """Utility method for performing HTTP call to Salesforce.
+
+    Returns a `requests.result` object.
+    """
+
+    additional_headers = kwargs.pop('additional_headers', dict())
+    headers.update(additional_headers or dict())
+    result = self.session.request(method, url, headers=headers, **kwargs)
+
+    if result.status_code >= 300:
+        _exception_handler(result, self.name)
+
+    return result
 
 def _exception_handler(result, name=""):
     """Exception router. Determines which error to raise for bad results"""

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -17,7 +17,7 @@ except ImportError:
     from urllib.parse import urlparse, urljoin
 from simple_salesforce.login import SalesforceLogin
 from simple_salesforce.util import date_to_iso8601, SalesforceError
-from simple_salesforce.bulk import SFBulkHandler, SFBulkType
+from simple_salesforce.bulk import SFBulkHandler
 
 try:
     from collections import OrderedDict

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -164,6 +164,9 @@ class Salesforce(object):
                                  version=self.sf_version))
         self.apex_url = ('https://{instance}/services/apexrest/'
                          .format(instance=self.sf_instance))
+        self.bulk_url = ('https://{instance}/services/async/{version}/'
+                         .format(instance=self.sf_instance,
+                                 version=self.sf_version))
 
     def describe(self):
         """Describes all available objects

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -808,6 +808,11 @@ class SFBulkType(object):
         result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=json.dumps(data))
         return result.json(object_pairs_hook=OrderedDict)
 
+    def __attr__(self, name):
+        """ handling function here """
+
+        return True
+
 
 class SalesforceAPI(Salesforce):
     """Deprecated SalesforceAPI Instance

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -824,7 +824,7 @@ class SalesforceAPI(Salesforce):
                                             sandbox=sandbox,
                                             version=sf_version)
 
-def _call_salesforce(url, method, headers, **kwargs):
+def _call_salesforce(url, method, session, headers, **kwargs):
     """Utility method for performing HTTP call to Salesforce.
 
     Returns a `requests.result` object.
@@ -832,7 +832,7 @@ def _call_salesforce(url, method, headers, **kwargs):
 
     additional_headers = kwargs.pop('additional_headers', dict())
     headers.update(additional_headers or dict())
-    result = self.session.request(method, url, headers=headers, **kwargs)
+    result = session.request(method, url, headers=headers, **kwargs)
 
     if result.status_code >= 300:
         _exception_handler(result, self.name)

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -800,6 +800,14 @@ class SFBulkType(object):
         result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=json.dumps(payload))
         return result.json(object_pairs_hook=OrderedDict)
 
+    def _add_batch(self, job_id, data):
+        """ Add a set of data as a batch to an existing job """
+
+        url = self.bulk_url + '/' + job_id + '/batch'
+
+        result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=json.dumps(data))
+        return result.json(object_pairs_hook=OrderedDict)
+
 
 class SalesforceAPI(Salesforce):
     """Deprecated SalesforceAPI Instance

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -1,3 +1,15 @@
+""" Classes for interacting with Salesforce Bulk API """
+
+import requests
+import json
+from time import sleep
+from simple_salesforce.util import SalesforceError
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    # Python < 2.7
+    from ordereddict import OrderedDict
 
 class SFBulkHandler(object):
     """ Bulk API request handler
@@ -5,13 +17,12 @@ class SFBulkHandler(object):
     This is really just a middle layer, whose sole purpose is to allow the above syntax
     """
 
-    def __init__(self, session_id, sf_instance, bulk_url, proxies=None, session=None):
+    def __init__(self, session_id, bulk_url, proxies=None, session=None):
         """Initialize the instance with the given parameters.
 
         Arguments:
 
         * session_id -- the session ID for authenticating to Salesforce
-        * sf_instance -- the domain of the instance of Salesforce to use
         * bulk_url -- API endpoint set in Salesforce instance
         * proxies -- the optional map of scheme to proxy server
         * session -- Custom requests session, created in calling code. This
@@ -72,7 +83,7 @@ class SFBulkType(object):
             'contentType': 'JSON'
         }
 
-        if operation=='upsert':
+        if operation == 'upsert':
             payload['externalIdFieldName'] = external_id_field
 
         url = self.bulk_url + 'job'
@@ -142,7 +153,7 @@ class SFBulkType(object):
 
         batch = self._add_batch(job_id=job['id'], data=data)
 
-        job_close = self._close_job(job_id=job['id'])
+        self._close_job(job_id=job['id'])
 
         batch_status = self._get_batch(job_id=batch['jobId'], batch_id=batch['id'])['state']
 

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -166,32 +166,32 @@ class SFBulkType(object):
 
     # Wrappers for _bulk_operation which expose the supported Salesforce bulk operations
     def delete(self, data):
-
+        """ soft delete records """
         results = self._bulk_operation(object_name=self.object_name, operation='delete', data=data)
         return results
 
     def insert(self, data):
-
+        """ insert records """
         results = self._bulk_operation(object_name=self.object_name, operation='insert', data=data)
         return results
 
     def upsert(self, data, external_id_field):
-
+        """ upsert records based on a unique identifier """
         results = self._bulk_operation(object_name=self.object_name, operation='upsert', external_id_field=external_id_field, data=data)
         return results
 
     def update(self, data):
-
+        """ update records """
         results = self._bulk_operation(object_name=self.object_name, operation='update', data=data)
         return results
 
     def hard_delete(self, data):
-
+        """ hard delete records """
         results = self._bulk_operation(object_name=self.object_name, operation='hardDelete', data=data)
         return results
 
     def query(self, data):
-
+        """ bulk query """
         results = self._bulk_operation(object_name=self.object_name, operation='query', data=data)
         return results
 

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -57,7 +57,14 @@ class SFBulkType(object):
         self.headers = headers
 
     def _create_job(self, operation, object_name, external_id_field=None):
-        """ Create a bulk job """
+        """ Create a bulk job
+
+        Arguments:
+
+        * operation -- Bulk operation to be performed by job
+        * object_name -- SF object
+        * external_id_field -- unique identifier field for upsert operations
+        """
 
         payload = {
             'operation': operation,
@@ -120,7 +127,16 @@ class SFBulkType(object):
         return result.json()
 
     def _bulk_operation(self, object_name, operation, data, external_id_field=None, wait=5):
-        """ String together helper functions to create a complete end-to-end bulk API request """
+        """ String together helper functions to create a complete end-to-end bulk API request
+
+        Arguments:
+
+        * object_name -- SF object
+        * operation -- Bulk operation to be performed by job
+        * data -- list of dict to be passed as a batch
+        * external_id_field -- unique identifier field for upsert operations
+        * wait -- seconds to sleep between checking batch status
+        """
 
         job = self._create_job(object_name=object_name, operation=operation, external_id_field=external_id_field)
 

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -1,0 +1,265 @@
+
+class SFBulkHandler(object):
+    """ Bulk API request handler
+    Intermediate class which allows us to use commands such as 'sf.bulk.Contacts.create(...)'
+    This is really just a middle layer, whose sole purpose is to allow the above syntax
+    """
+
+    def __init__(self, session_id, sf_instance, bulk_url, proxies=None, session=None):
+        """Initialize the instance with the given parameters.
+
+        Arguments:
+
+        * session_id -- the session ID for authenticating to Salesforce
+        * sf_instance -- the domain of the instance of Salesforce to use
+        * bulk_url -- API endpoint set in Salesforce instance
+        * proxies -- the optional map of scheme to proxy server
+        * session -- Custom requests session, created in calling code. This
+                     enables the use of requests Session features not otherwise
+                     exposed by simple_salesforce.
+        """
+        self.session_id = session_id
+        self.session = session or requests.Session()
+        self.bulk_url = bulk_url
+        # don't wipe out original proxies with None
+        if not session and proxies is not None:
+            self.session.proxies = proxies
+
+        # Define these headers separate from Salesforce class, as bulk uses a slightly different format
+        self.headers = {
+            'Content-Type': 'application/json',
+            'X-SFDC-Session': self.session_id,
+            'X-PrettyPrint': '1'
+        }
+
+    def __getattr__(self, name):
+        return SFBulkType(object_name=name, bulk_url=self.bulk_url, headers=self.headers, session=self.session)
+
+class SFBulkType(object):
+    """ Interface to Bulk/Async API functions"""
+
+    def __init__(self, object_name, bulk_url, headers, session):
+        """Initialize the instance with the given parameters.
+
+        Arguments:
+
+        * object_name -- the name of the type of SObject this represents,
+                         e.g. `Lead` or `Contact`
+        * bulk_url -- API endpoint set in Salesforce instance
+        * headers -- bulk API headers
+        * session -- Custom requests session, created in calling code. This
+                     enables the use of requests Session features not otherwise
+                     exposed by simple_salesforce.
+        """
+        self.object_name = object_name
+        self.bulk_url = bulk_url
+        self.session = session
+        self.headers = headers
+
+    def _create_job(self, operation, object_name, external_id_field=None):
+        """ Create a bulk job """
+
+        payload = {
+            'operation': operation,
+            'object': object_name,
+            'contentType': 'JSON'
+        }
+
+        if operation=='upsert':
+            payload['externalIdFieldName'] = external_id_field
+
+        url = self.bulk_url + 'job'
+
+        result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=json.dumps(payload))
+        return result.json(object_pairs_hook=OrderedDict)
+
+    def _close_job(self, job_id):
+        """ Close a bulk job """
+
+        payload = {
+            'state': 'Closed'
+        }
+
+        url = self.bulk_url + 'job/' + job_id
+
+        result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=json.dumps(payload))
+        return result.json(object_pairs_hook=OrderedDict)
+
+    def _get_job(self, job_id):
+        """ Get an existing job to check the status """
+
+        url = self.bulk_url + 'job/' + job_id
+
+        result = _call_salesforce(url=url, method='GET', session=self.session, headers=self.headers)
+        return result.json(object_pairs_hook=OrderedDict)
+
+    def _add_batch(self, job_id, data):
+        """ Add a set of data as a batch to an existing job
+        Separating this out in case of later implementations involving multiple batches
+        """
+
+        url = self.bulk_url + 'job/' + job_id + '/batch'
+
+        result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=json.dumps(data))
+        return result.json(object_pairs_hook=OrderedDict)
+
+    def _get_batch(self, job_id, batch_id):
+        """ Get an existing batch to check the status """
+
+        url = self.bulk_url + 'job/' + job_id + '/batch/' + batch_id
+
+        result = _call_salesforce(url=url, method='GET', session=self.session, headers=self.headers)
+        return result.json(object_pairs_hook=OrderedDict)
+
+    def _get_batch_results(self, job_id, batch_id):
+        """ retrieve a set of results from a completed job """
+
+        url = self.bulk_url + 'job/' + job_id + '/batch/' + batch_id + '/result'
+
+        result = _call_salesforce(url=url, method='GET', session=self.session, headers=self.headers)
+        return result.json()
+
+    def _bulk_operation(self, object_name, operation, data, external_id_field=None, wait=5):
+        """ String together helper functions to create a complete end-to-end bulk API request """
+
+        job = self._create_job(object_name=object_name, operation=operation, external_id_field=external_id_field)
+
+        batch = self._add_batch(job_id=job['id'], data=data)
+
+        job_close = self._close_job(job_id=job['id'])
+
+        batch_status = self._get_batch(job_id=batch['jobId'], batch_id=batch['id'])['state']
+
+        while batch_status not in ['Completed', 'Failed', 'Not Processed']:
+            sleep(wait)
+            batch_status = self._get_batch(job_id=batch['jobId'], batch_id=batch['id'])['state']
+
+        results = self._get_batch_results(job_id=batch['jobId'], batch_id=batch['id'])
+        return results
+
+    # Wrappers for _bulk_operation which expose the supported Salesforce bulk operations
+    def delete(self, data):
+
+        results = self._bulk_operation(object_name=self.object_name, operation='delete', data=data)
+        return results
+
+    def insert(self, data):
+
+        results = self._bulk_operation(object_name=self.object_name, operation='insert', data=data)
+        return results
+
+    def upsert(self, data, external_id_field):
+
+        results = self._bulk_operation(object_name=self.object_name, operation='upsert', external_id_field=external_id_field, data=data)
+        return results
+
+    def update(self, data):
+
+        results = self._bulk_operation(object_name=self.object_name, operation='update', data=data)
+        return results
+
+    def hard_delete(self, data):
+
+        results = self._bulk_operation(object_name=self.object_name, operation='hardDelete', data=data)
+        return results
+
+    def query(self, data):
+
+        results = self._bulk_operation(object_name=self.object_name, operation='query', data=data)
+        return results
+
+# TODO: refactor _call_salesforce, _exception_handler, and exception classes into util.py for common access between different API handlers
+
+def _call_salesforce(url, method, session, headers, **kwargs):
+    """Utility method for performing HTTP call to Salesforce.
+
+    Returns a `requests.result` object.
+    """
+
+    additional_headers = kwargs.pop('additional_headers', dict())
+    headers.update(additional_headers or dict())
+    result = session.request(method, url, headers=headers, **kwargs)
+
+    if result.status_code >= 300:
+        _exception_handler(result)
+
+    return result
+
+
+def _exception_handler(result, name=""):
+    """Exception router. Determines which error to raise for bad results"""
+    try:
+        response_content = result.json()
+    # pylint: disable=broad-except
+    except Exception:
+        response_content = result.text
+
+    exc_map = {
+        300: SalesforceMoreThanOneRecord,
+        400: SalesforceMalformedRequest,
+        401: SalesforceExpiredSession,
+        403: SalesforceRefusedRequest,
+        404: SalesforceResourceNotFound,
+    }
+    exc_cls = exc_map.get(result.status_code, SalesforceGeneralError)
+
+    raise exc_cls(result.url, result.status_code, name, response_content)
+
+
+class SalesforceMoreThanOneRecord(SalesforceError):
+    """
+    Error Code: 300
+    The value returned when an external ID exists in more than one record. The
+    response body contains the list of matching records.
+    """
+    message = u"More than one record for {url}. Response content: {content}"
+
+
+class SalesforceMalformedRequest(SalesforceError):
+    """
+    Error Code: 400
+    The request couldn't be understood, usually becaue the JSON or XML body
+    contains an error.
+    """
+    message = u"Malformed request {url}. Response content: {content}"
+
+
+class SalesforceExpiredSession(SalesforceError):
+    """
+    Error Code: 401
+    The session ID or OAuth token used has expired or is invalid. The response
+    body contains the message and errorCode.
+    """
+    message = u"Expired session for {url}. Response content: {content}"
+
+
+class SalesforceRefusedRequest(SalesforceError):
+    """
+    Error Code: 403
+    The request has been refused. Verify that the logged-in user has
+    appropriate permissions.
+    """
+    message = u"Request refused for {url}. Response content: {content}"
+
+
+class SalesforceResourceNotFound(SalesforceError):
+    """
+    Error Code: 404
+    The requested resource couldn't be found. Check the URI for errors, and
+    verify that there are no sharing issues.
+    """
+    message = u'Resource {name} Not Found. Response content: {content}'
+
+    def __str__(self):
+        return self.message.format(name=self.resource_name,
+                                   content=self.content)
+
+
+class SalesforceGeneralError(SalesforceError):
+    """
+    A non-specific Salesforce error.
+    """
+    message = u'Error Code {status}. Response content: {content}'
+
+    def __str__(self):
+        return self.message.format(status=self.status, content=self.content)

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -86,7 +86,7 @@ class SFBulkType(object):
         if operation == 'upsert':
             payload['externalIdFieldName'] = external_id_field
 
-        url = self.bulk_url + 'job'
+        url = "{}{}".format(self.bulk_url, 'job')
 
         result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=json.dumps(payload))
         return result.json(object_pairs_hook=OrderedDict)
@@ -98,7 +98,7 @@ class SFBulkType(object):
             'state': 'Closed'
         }
 
-        url = self.bulk_url + 'job/' + job_id
+        url = "{}{}{}".format(self.bulk_url, 'job/', job_id)
 
         result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=json.dumps(payload))
         return result.json(object_pairs_hook=OrderedDict)
@@ -106,7 +106,7 @@ class SFBulkType(object):
     def _get_job(self, job_id):
         """ Get an existing job to check the status """
 
-        url = self.bulk_url + 'job/' + job_id
+        url = "{}{}{}".format(self.bulk_url, 'job/', job_id)
 
         result = _call_salesforce(url=url, method='GET', session=self.session, headers=self.headers)
         return result.json(object_pairs_hook=OrderedDict)
@@ -116,7 +116,7 @@ class SFBulkType(object):
         Separating this out in case of later implementations involving multiple batches
         """
 
-        url = self.bulk_url + 'job/' + job_id + '/batch'
+        url = "{}{}{}{}".format(self.bulk_url, 'job/', job_id, '/batch')
 
         if operation != 'query':
             data = json.dumps(data)
@@ -127,7 +127,7 @@ class SFBulkType(object):
     def _get_batch(self, job_id, batch_id):
         """ Get an existing batch to check the status """
 
-        url = self.bulk_url + 'job/' + job_id + '/batch/' + batch_id
+        url = "{}{}{}{}{}".format(self.bulk_url, 'job/', job_id, '/batch/', batch_id)
 
         result = _call_salesforce(url=url, method='GET', session=self.session, headers=self.headers)
         return result.json(object_pairs_hook=OrderedDict)
@@ -135,12 +135,12 @@ class SFBulkType(object):
     def _get_batch_results(self, job_id, batch_id, operation):
         """ retrieve a set of results from a completed job """
 
-        url = self.bulk_url + 'job/' + job_id + '/batch/' + batch_id + '/result'
+        url = "{}{}{}{}{}{}".format(self.bulk_url, 'job/', job_id, '/batch/', batch_id, '/result')
 
         result = _call_salesforce(url=url, method='GET', session=self.session, headers=self.headers)
 
         if operation == 'query':
-            url_query_results = url + '/' + result.json()[0]
+            url_query_results = "{}{}{}".format(url, '/', result.json()[0])
             query_result = _call_salesforce(url=url_query_results, method='GET', session=self.session, headers=self.headers)
             return query_result.json()
 

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -164,7 +164,7 @@ class SFBulkType(object):
         return result.json()
 
     def _bulk_operation(self, object_name, operation, data,
-                        external_id_field=None, wait=5):
+                        external_id_field=None, wait=5): #pylint: disable=R0913
         """ String together helper functions to create a complete
         end-to-end bulk API request
 

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -1,7 +1,5 @@
 """ Classes for interacting with Salesforce Bulk API """
 
-WAIT = 5
-
 try:
     from collections import OrderedDict
 except ImportError:
@@ -166,7 +164,7 @@ class SFBulkType(object):
         return result.json()
 
     def _bulk_operation(self, object_name, operation, data,
-                        external_id_field=None):
+                        external_id_field=None, wait=5):
         """ String together helper functions to create a complete
         end-to-end bulk API request
 
@@ -191,7 +189,7 @@ class SFBulkType(object):
                                        batch_id=batch['id'])['state']
 
         while batch_status not in ['Completed', 'Failed', 'Not Processed']:
-            sleep(WAIT)
+            sleep(wait)
             batch_status = self._get_batch(job_id=batch['jobId'],
                                            batch_id=batch['id'])['state']
 

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -13,8 +13,10 @@ except ImportError:
 
 class SFBulkHandler(object):
     """ Bulk API request handler
-    Intermediate class which allows us to use commands such as 'sf.bulk.Contacts.create(...)'
-    This is really just a middle layer, whose sole purpose is to allow the above syntax
+    Intermediate class which allows us to use commands,
+     such as 'sf.bulk.Contacts.create(...)'
+    This is really just a middle layer, whose sole purpose is
+    to allow the above syntax
     """
 
     def __init__(self, session_id, bulk_url, proxies=None, session=None):
@@ -36,7 +38,8 @@ class SFBulkHandler(object):
         if not session and proxies is not None:
             self.session.proxies = proxies
 
-        # Define these headers separate from Salesforce class, as bulk uses a slightly different format
+        # Define these headers separate from Salesforce class,
+        # as bulk uses a slightly different format
         self.headers = {
             'Content-Type': 'application/json',
             'X-SFDC-Session': self.session_id,
@@ -44,7 +47,8 @@ class SFBulkHandler(object):
         }
 
     def __getattr__(self, name):
-        return SFBulkType(object_name=name, bulk_url=self.bulk_url, headers=self.headers, session=self.session)
+        return SFBulkType(object_name=name, bulk_url=self.bulk_url,
+                          headers=self.headers, session=self.session)
 
 class SFBulkType(object):
     """ Interface to Bulk/Async API functions"""
@@ -88,7 +92,8 @@ class SFBulkType(object):
 
         url = "{}{}".format(self.bulk_url, 'job')
 
-        result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=json.dumps(payload))
+        result = _call_salesforce(url=url, method='POST', session=self.session,
+                                headers=self.headers, data=json.dumps(payload))
         return result.json(object_pairs_hook=OrderedDict)
 
     def _close_job(self, job_id):
@@ -100,7 +105,8 @@ class SFBulkType(object):
 
         url = "{}{}{}".format(self.bulk_url, 'job/', job_id)
 
-        result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=json.dumps(payload))
+        result = _call_salesforce(url=url, method='POST', session=self.session,
+                                headers=self.headers, data=json.dumps(payload))
         return result.json(object_pairs_hook=OrderedDict)
 
     def _get_job(self, job_id):
@@ -108,12 +114,14 @@ class SFBulkType(object):
 
         url = "{}{}{}".format(self.bulk_url, 'job/', job_id)
 
-        result = _call_salesforce(url=url, method='GET', session=self.session, headers=self.headers)
+        result = _call_salesforce(url=url, method='GET', session=self.session,
+                                  headers=self.headers)
         return result.json(object_pairs_hook=OrderedDict)
 
     def _add_batch(self, job_id, data, operation):
         """ Add a set of data as a batch to an existing job
-        Separating this out in case of later implementations involving multiple batches
+        Separating this out in case of later
+        implementations involving multiple batches
         """
 
         url = "{}{}{}{}".format(self.bulk_url, 'job/', job_id, '/batch')
@@ -121,33 +129,41 @@ class SFBulkType(object):
         if operation != 'query':
             data = json.dumps(data)
 
-        result = _call_salesforce(url=url, method='POST', session=self.session, headers=self.headers, data=data)
+        result = _call_salesforce(url=url, method='POST', session=self.session,
+                                  headers=self.headers, data=data)
         return result.json(object_pairs_hook=OrderedDict)
 
     def _get_batch(self, job_id, batch_id):
         """ Get an existing batch to check the status """
 
-        url = "{}{}{}{}{}".format(self.bulk_url, 'job/', job_id, '/batch/', batch_id)
+        url = "{}{}{}{}{}".format(self.bulk_url, 'job/',
+                                  job_id, '/batch/', batch_id)
 
-        result = _call_salesforce(url=url, method='GET', session=self.session, headers=self.headers)
+        result = _call_salesforce(url=url, method='GET', session=self.session,
+                                  headers=self.headers)
         return result.json(object_pairs_hook=OrderedDict)
 
     def _get_batch_results(self, job_id, batch_id, operation):
         """ retrieve a set of results from a completed job """
 
-        url = "{}{}{}{}{}{}".format(self.bulk_url, 'job/', job_id, '/batch/', batch_id, '/result')
+        url = "{}{}{}{}{}{}".format(self.bulk_url, 'job/', job_id, '/batch/',
+                                    batch_id, '/result')
 
-        result = _call_salesforce(url=url, method='GET', session=self.session, headers=self.headers)
+        result = _call_salesforce(url=url, method='GET', session=self.session,
+                                  headers=self.headers)
 
         if operation == 'query':
             url_query_results = "{}{}{}".format(url, '/', result.json()[0])
-            query_result = _call_salesforce(url=url_query_results, method='GET', session=self.session, headers=self.headers)
+            query_result = _call_salesforce(url=url_query_results, method='GET',
+                                    session=self.session, headers=self.headers)
             return query_result.json()
 
         return result.json()
 
-    def _bulk_operation(self, object_name, operation, data, external_id_field=None, wait=5):
-        """ String together helper functions to create a complete end-to-end bulk API request
+    def _bulk_operation(self, object_name, operation, data,
+                        external_id_field=None, wait=5):
+        """ String together helper functions to create a complete
+        end-to-end bulk API request
 
         Arguments:
 
@@ -158,53 +174,68 @@ class SFBulkType(object):
         * wait -- seconds to sleep between checking batch status
         """
 
-        job = self._create_job(object_name=object_name, operation=operation, external_id_field=external_id_field)
+        job = self._create_job(object_name=object_name, operation=operation,
+                               external_id_field=external_id_field)
 
-        batch = self._add_batch(job_id=job['id'], data=data, operation=operation)
+        batch = self._add_batch(job_id=job['id'], data=data,
+                                operation=operation)
 
         self._close_job(job_id=job['id'])
 
-        batch_status = self._get_batch(job_id=batch['jobId'], batch_id=batch['id'])['state']
+        batch_status = self._get_batch(job_id=batch['jobId'],
+                                       batch_id=batch['id'])['state']
 
         while batch_status not in ['Completed', 'Failed', 'Not Processed']:
             sleep(wait)
-            batch_status = self._get_batch(job_id=batch['jobId'], batch_id=batch['id'])['state']
+            batch_status = self._get_batch(job_id=batch['jobId'],
+                                           batch_id=batch['id'])['state']
 
-        results = self._get_batch_results(job_id=batch['jobId'], batch_id=batch['id'], operation=operation)
+        results = self._get_batch_results(job_id=batch['jobId'],
+                                    batch_id=batch['id'], operation=operation)
         return results
 
-    # Wrappers for _bulk_operation which expose the supported Salesforce bulk operations
+    # _bulk_operation wrappers to expose supported Salesforce bulk operations
     def delete(self, data):
         """ soft delete records """
-        results = self._bulk_operation(object_name=self.object_name, operation='delete', data=data)
+        results = self._bulk_operation(object_name=self.object_name,
+                                       operation='delete', data=data)
         return results
 
     def insert(self, data):
         """ insert records """
-        results = self._bulk_operation(object_name=self.object_name, operation='insert', data=data)
+        results = self._bulk_operation(object_name=self.object_name,
+                                       operation='insert', data=data)
         return results
 
     def upsert(self, data, external_id_field):
         """ upsert records based on a unique identifier """
-        results = self._bulk_operation(object_name=self.object_name, operation='upsert', external_id_field=external_id_field, data=data)
+        results = self._bulk_operation(object_name=self.object_name,
+                                       operation='upsert',
+                                       external_id_field=external_id_field,
+                                       data=data)
         return results
 
     def update(self, data):
         """ update records """
-        results = self._bulk_operation(object_name=self.object_name, operation='update', data=data)
+        results = self._bulk_operation(object_name=self.object_name,
+                                       operation='update', data=data)
         return results
 
     def hard_delete(self, data):
         """ hard delete records """
-        results = self._bulk_operation(object_name=self.object_name, operation='hardDelete', data=data)
+        results = self._bulk_operation(object_name=self.object_name,
+                                       operation='hardDelete', data=data)
         return results
 
     def query(self, data):
         """ bulk query """
-        results = self._bulk_operation(object_name=self.object_name, operation='query', data=data)
+        results = self._bulk_operation(object_name=self.object_name,
+                                       operation='query', data=data)
         return results
 
-# TODO: refactor _call_salesforce, _exception_handler, and exception classes into util.py for common access between different API handlers
+# TODO: refactor _call_salesforce, _exception_handler,
+#       and exception classes into util.py for common
+#       access between different API handlers
 
 def _call_salesforce(url, method, session, headers, **kwargs):
     """Utility method for performing HTTP call to Salesforce.


### PR DESCRIPTION
Adding support for Bulk API according to discussions in #112 . 

- Split out bulk classes into `bulk.py` as a proposed model for splitting other services; this way, the handling classes for each API type would live in it's own file, making the code more manageable. 
- Added example docs to README
- I've tested in the sandbox available to me, with a few object types. 

Potential edits/discussion: 

- To get the format mentioned in #112, `sf.bulk.Contact.do_something()`, had to create two new classes, `SFBulkHandler` and `SFBulkType`. I'm not entirely happy with `SFBulkHandler` as a solution, since it's only purpose is to parse out the SF object type and pass to `SFBulkType`. If anyone has ideas on how to better handle this, let me know and I'll work it in. Another alternative is to use the format `sf.bulk.do_something(object='Contact')`, but that is less intuitive. 
- `_call_salesforce()` now gets defined three times in this codebase (twice in `api.py` and once in `bulk.py`). As a todo, might be nice to generalize and move to the `util.py` file, along with `_exception_handler()`; especially would make split services easier to implement. 
- What types of unit tests are appropriate here? Looking at the current tests, I'm not sure there's much we could add that wouldn't be dependent on API version. If any suggestions, let me know and I can either build into this PR or create a separate PR later. 