### PR TITLE
Added license to the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE.txt
 include README.rst
 include MANIFEST.in


### PR DESCRIPTION
In order to easily package this library on conda forge we should include the license file in the source tarball.