### PR TITLE
Send simple Email via simple-salesforce

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -201,9 +201,9 @@ class Salesforce(object):
         if name.startswith('__'):
             return super(Salesforce, self).__getattr__(name)
 
-        if name == 'Email':
-            return SFemailSimple(self.session_id, self.sf_instance,
-                                 proxies=self.proxies, session=self.session)
+        if name == 'Action':
+            return SFAction(self.session_id, self.sf_instance,
+                            proxies=self.proxies, session=self.session)
 
         return SFType(
             name, self.session_id, self.sf_instance, sf_version=self.sf_version,
@@ -450,16 +450,18 @@ class Salesforce(object):
         _warn_request_deprecation()
         self.session = session
 
-class SFemailSimple(object):
-    """Interface for simpleEmail Action"""
+class SFAction(object):
+    """Interface for Salesforce Action.
+       Currently only simpleEmail is implemented. 
+       More actions coming in the future
+    """
 
     # pylint: disable=too-many-arguments
     def __init__(self, session_id, sf_instance,
             sf_version='32.0', proxies=None, session=None):
         """
-        Initialize emailSimple action. Note
-        - the base_url is different from the url of sobjects
-        - this is only available after version 32.0 
+        Initialize SF Action. Note some actions are only available after version 32.0,
+         so we use default sf_version='32.0'
         """
         self.session_id = session_id
         self.session = session or requests.Session()
@@ -467,11 +469,11 @@ class SFemailSimple(object):
             self.session.proxies = proxies
         self.sf_version = sf_version
 
-        self.url = (
-            u'https://{instance}/services/data/v{sf_version}/actions/standard/emailSimple/'
+        self.base_url = (
+            u'https://{instance}/services/data/v{sf_version}/actions/'
                 .format(instance=sf_instance, sf_version=sf_version))
 
-    def send(self,  emailAddresses, emailSubject, emailBody):
+    def emailSimple(self,  emailAddresses, emailSubject, emailBody):
         """Utility method for sending simpleEmail via Salesforce.
         :param EmailAdresses: string like "user1@email.com,user2@email.com"
         :param emailSubject:  string like "An email from salesforce",
@@ -495,12 +497,12 @@ class SFemailSimple(object):
         ]
         }
 
-        result = self.session.request('POST', self.url, headers=headers,
-                                      data=json.dumps(email_data))
+        result = self.session.request('POST', urljoin(self.base_url, 'standard/emailSimple/'),
+                    headers=headers, data=json.dumps(email_data))
 
         if result.status_code >= 300:
-
             _exception_handler(result, 'simpleEmail')
+            
         return result
 
 class SFType(object):

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -32,13 +32,13 @@ from simple_salesforce.api import (
     SalesforceResourceNotFound,
     SalesforceGeneralError,
     SFType,
-    SFemailSimple
+    SFAction
 )
 
 def _create_sf_emailSimple(object_name='Case', session_id='5',
                            sf_instance='my.salesforce.com'):
     """Creates SF emailSimple instances"""
-    return SFemailSimple(
+    return SFAction(
         object_name=object_name,
         session_id=session_id,
         sf_instance=sf_instance,

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -31,8 +31,33 @@ from simple_salesforce.api import (
     SalesforceRefusedRequest,
     SalesforceResourceNotFound,
     SalesforceGeneralError,
-    SFType
+    SFType,
+    SFemailSimple
 )
+
+def _create_sf_emailSimple(object_name='Case', session_id='5',
+                           sf_instance='my.salesforce.com'):
+    """Creates SF emailSimple instances"""
+    return SFemailSimple(
+        object_name=object_name,
+        session_id=session_id,
+        sf_instance=sf_instance,
+        session=requests.Session()
+    )
+
+
+class TestSFEmailSimple(unittest.TestCase):
+    """Tests for SFEmailSimple instance"""
+    def setUp(self):
+        request_patcher = patch('simple_salesforce.api.requests')
+        self.mockrequest = request_patcher.start()
+        self.addCleanup(request_patcher.stop)
+
+    @responses.activate
+    def test_version(self):
+        emailSimple = _create_sf_emailSimple()
+        self.assertGreaterEqual(float(emailSimple.sf_version), 32.0)
+
 
 
 def _create_sf_type(


### PR DESCRIPTION
this is a  function motivated by issue #163. 

Basically I added a new class SFAction and add it to Salesforce.getattr(self, name) as the following:

```
def __getattr__(self, name):
    if name.startswith('__'):
            return super(Salesforce, self).__getattr__(name)

    if name == 'Action':  return SFAction(self.session_id, self.sf_instance,
                            proxies=self.proxies, session=self.session)

   return SFType(...)
```
and the SFAction class implements emailSimple() and hopefully also other actions in the future.

Several notes:

- I use REST API instead of SOAP based on this [doc](https://resources.docs.salesforce.com/sfdc/pdf/api_action.pdf). I don't know whether SOAP is a better choice. 

- simpleEmail exists only after version 32.0. With DEFAULT_API_VERSION = '29.0', it will report some error like "resource does not exist".

I also tried with my sandbox account and got correct status_code, but I just could not receive the email. Haven't figured out the reason, just hoping the problem lies in my sandbox setting instead of the code.

Thanks for the suggestions. More comments are welcome.
 


