### PR TITLE
Move exceptions to exceptions.py

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -38,7 +38,7 @@ load-plugins=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=too-many-public-methods,too-few-public-methods,no-member,super-on-old-class,too-many-ancestors,I0011,deprecated-disable-all,file-ignored,import-error,no-name-in-module,maybe-no-member,fixme,duplicate-code,cyclic-import,wrong-import-order,wrong-import-position,ungrouped-imports,redefined-variable-type,bad-continuation
+disable=too-many-public-methods,too-few-public-methods,no-member,super-on-old-class,too-many-ancestors,I0011,deprecated-disable-all,file-ignored,import-error,no-name-in-module,maybe-no-member,fixme,duplicate-code,cyclic-import,wrong-import-order,wrong-import-position,ungrouped-imports,redefined-variable-type,bad-continuation,len-as-condition
 
 
 [REPORTS]

--- a/simple_salesforce/__init__.py
+++ b/simple_salesforce/__init__.py
@@ -4,16 +4,20 @@
 from simple_salesforce.api import (
     Salesforce,
     SalesforceAPI,
-    SFType,
+    SFType
+)
+
+from simple_salesforce.login import (
+    SalesforceLogin
+)
+
+from simple_salesforce.exceptions import (
     SalesforceError,
     SalesforceMoreThanOneRecord,
     SalesforceExpiredSession,
     SalesforceRefusedRequest,
     SalesforceResourceNotFound,
     SalesforceGeneralError,
-    SalesforceMalformedRequest
-)
-
-from simple_salesforce.login import (
-    SalesforceLogin, SalesforceAuthenticationFailed
+    SalesforceMalformedRequest,
+    SalesforceAuthenticationFailed
 )

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -16,7 +16,12 @@ except ImportError:
     # Python 3+
     from urllib.parse import urlparse, urljoin
 from simple_salesforce.login import SalesforceLogin
-from simple_salesforce.util import date_to_iso8601, SalesforceError
+from simple_salesforce.util import date_to_iso8601
+from simple_salesforce.exceptions import (
+    SalesforceGeneralError, SalesforceExpiredSession,
+    SalesforceMalformedRequest, SalesforceMoreThanOneRecord,
+    SalesforceRefusedRequest, SalesforceResourceNotFound
+)
 
 try:
     from collections import OrderedDict
@@ -792,60 +797,3 @@ def _exception_handler(result, name=""):
     raise exc_cls(result.url, result.status_code, name, response_content)
 
 
-class SalesforceMoreThanOneRecord(SalesforceError):
-    """
-    Error Code: 300
-    The value returned when an external ID exists in more than one record. The
-    response body contains the list of matching records.
-    """
-    message = u"More than one record for {url}. Response content: {content}"
-
-
-class SalesforceMalformedRequest(SalesforceError):
-    """
-    Error Code: 400
-    The request couldn't be understood, usually because the JSON or XML body
-    contains an error.
-    """
-    message = u"Malformed request {url}. Response content: {content}"
-
-
-class SalesforceExpiredSession(SalesforceError):
-    """
-    Error Code: 401
-    The session ID or OAuth token used has expired or is invalid. The response
-    body contains the message and errorCode.
-    """
-    message = u"Expired session for {url}. Response content: {content}"
-
-
-class SalesforceRefusedRequest(SalesforceError):
-    """
-    Error Code: 403
-    The request has been refused. Verify that the logged-in user has
-    appropriate permissions.
-    """
-    message = u"Request refused for {url}. Response content: {content}"
-
-
-class SalesforceResourceNotFound(SalesforceError):
-    """
-    Error Code: 404
-    The requested resource couldn't be found. Check the URI for errors, and
-    verify that there are no sharing issues.
-    """
-    message = u'Resource {name} Not Found. Response content: {content}'
-
-    def __str__(self):
-        return self.message.format(name=self.resource_name,
-                                   content=self.content)
-
-
-class SalesforceGeneralError(SalesforceError):
-    """
-    A non-specific Salesforce error.
-    """
-    message = u'Error Code {status}. Response content: {content}'
-
-    def __str__(self):
-        return self.message.format(status=self.status, content=self.content)

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -183,8 +183,8 @@ class Salesforce(object):
         json_result = result.json(object_pairs_hook=OrderedDict)
         if len(json_result) == 0:
             return None
-        else:
-            return json_result
+
+        return json_result
 
     # SObject Handler
     def __getattr__(self, name):
@@ -237,8 +237,8 @@ class Salesforce(object):
         json_result = result.json(object_pairs_hook=OrderedDict)
         if len(json_result) == 0:
             return None
-        else:
-            return json_result
+
+        return json_result
 
     # pylint: disable=invalid-name
     def setPassword(self, user, password):
@@ -281,8 +281,8 @@ class Salesforce(object):
         json_result = result.json(object_pairs_hook=OrderedDict)
         if len(json_result) == 0:
             return None
-        else:
-            return json_result
+
+        return json_result
 
     # Search Functions
     def search(self, search):
@@ -307,8 +307,8 @@ class Salesforce(object):
         json_result = result.json(object_pairs_hook=OrderedDict)
         if len(json_result) == 0:
             return None
-        else:
-            return json_result
+
+        return json_result
 
     def quick_search(self, search):
         """Returns the result of a Salesforce search as a dict decoded from
@@ -726,8 +726,8 @@ class SFType(object):
         """
         if not body_flag:
             return response.status_code
-        else:
-            return response
+
+        return response
 
     @property
     def request(self):
@@ -795,5 +795,3 @@ def _exception_handler(result, name=""):
     exc_cls = exc_map.get(result.status_code, SalesforceGeneralError)
 
     raise exc_cls(result.url, result.status_code, name, response_content)
-
-

--- a/simple_salesforce/exceptions.py
+++ b/simple_salesforce/exceptions.py
@@ -1,0 +1,105 @@
+"""All exceptions for Simple Salesforce"""
+
+
+class SalesforceError(Exception):
+    """Base Salesforce API exception"""
+
+    message = u'Unknown error occurred for {url}. Response content: {content}'
+
+    def __init__(self, url, status, resource_name, content):
+        """Initialize the SalesforceError exception
+
+        SalesforceError is the base class of exceptions in simple-salesforce
+
+        Args:
+            url: Salesforce URL that was called
+            status: Status code of the error response
+            resource_name: Name of the Salesforce resource being queried
+            content: content of the response
+        """
+        # TODO exceptions don't seem to be using parent constructors at all.
+        # this should be fixed.
+        # pylint: disable=super-init-not-called
+        self.url = url
+        self.status = status
+        self.resource_name = resource_name
+        self.content = content
+
+    def __str__(self):
+        return self.message.format(url=self.url, content=self.content)
+
+    def __unicode__(self):
+        return self.__str__()
+
+
+class SalesforceMoreThanOneRecord(SalesforceError):
+    """
+    Error Code: 300
+    The value returned when an external ID exists in more than one record. The
+    response body contains the list of matching records.
+    """
+    message = u"More than one record for {url}. Response content: {content}"
+
+
+class SalesforceMalformedRequest(SalesforceError):
+    """
+    Error Code: 400
+    The request couldn't be understood, usually because the JSON or XML body
+    contains an error.
+    """
+    message = u"Malformed request {url}. Response content: {content}"
+
+
+class SalesforceExpiredSession(SalesforceError):
+    """
+    Error Code: 401
+    The session ID or OAuth token used has expired or is invalid. The response
+    body contains the message and errorCode.
+    """
+    message = u"Expired session for {url}. Response content: {content}"
+
+
+class SalesforceRefusedRequest(SalesforceError):
+    """
+    Error Code: 403
+    The request has been refused. Verify that the logged-in user has
+    appropriate permissions.
+    """
+    message = u"Request refused for {url}. Response content: {content}"
+
+
+class SalesforceResourceNotFound(SalesforceError):
+    """
+    Error Code: 404
+    The requested resource couldn't be found. Check the URI for errors, and
+    verify that there are no sharing issues.
+    """
+    message = u'Resource {name} Not Found. Response content: {content}'
+
+    def __str__(self):
+        return self.message.format(name=self.resource_name,
+                                   content=self.content)
+
+class SalesforceAuthenticationFailed(SalesforceError):
+    """
+    Thrown to indicate that authentication with Salesforce failed.
+    """
+    def __init__(self, code, message):
+        # TODO exceptions don't seem to be using parent constructors at all.
+        # this should be fixed.
+        # pylint: disable=super-init-not-called
+        self.code = code
+        self.message = message
+
+    def __str__(self):
+        return u'{code}: {message}'.format(code=self.code,
+                                           message=self.message)
+
+class SalesforceGeneralError(SalesforceError):
+    """
+    A non-specific Salesforce error.
+    """
+    message = u'Error Code {status}. Response content: {content}'
+
+    def __str__(self):
+        return self.message.format(status=self.status, content=self.content)

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -8,7 +8,8 @@ DEFAULT_CLIENT_ID_PREFIX = 'RestForce'
 
 from simple_salesforce.api import DEFAULT_API_VERSION
 from simple_salesforce.util import getUniqueElementValueFromXmlString
-from simple_salesforce.util import SalesforceError
+from simple_salesforce.exceptions import SalesforceAuthenticationFailed
+
 try:
     # Python 3+
     from html import escape
@@ -56,9 +57,7 @@ def SalesforceLogin(
 
     soap_url = soap_url.format(domain=domain, sf_version=sf_version)
 
-    # pylint: disable=deprecated-method
     username = escape(username)
-    # pylint: disable=deprecated-method
     password = escape(password)
 
     # Check if token authentication is used
@@ -167,19 +166,3 @@ def SalesforceLogin(
                    .replace('-api', ''))
 
     return session_id, sf_instance
-
-
-class SalesforceAuthenticationFailed(SalesforceError):
-    """
-    Thrown to indicate that authentication with Salesforce failed.
-    """
-    def __init__(self, code, message):
-        # TODO exceptions don't seem to be using parent constructors at all.
-        # this should be fixed.
-        # pylint: disable=super-init-not-called
-        self.code = code
-        self.message = message
-
-    def __str__(self):
-        return u'{code}: {message}'.format(code=self.code,
-                                           message=self.message)

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -57,6 +57,7 @@ def SalesforceLogin(
 
     soap_url = soap_url.format(domain=domain, sf_version=sf_version)
 
+    # pylint: disable=E0012,deprecated-method
     username = escape(username)
     password = escape(password)
 

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -25,13 +25,15 @@ from simple_salesforce import tests
 from simple_salesforce.api import (
     _exception_handler,
     Salesforce,
+    SFType
+)
+from simple_salesforce.exceptions import (
     SalesforceMoreThanOneRecord,
     SalesforceMalformedRequest,
     SalesforceExpiredSession,
     SalesforceRefusedRequest,
     SalesforceResourceNotFound,
-    SalesforceGeneralError,
-    SFType
+    SalesforceGeneralError
 )
 
 

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -20,10 +20,8 @@ except ImportError:
     from urllib.parse import urlparse
 
 from simple_salesforce import tests
-from simple_salesforce.login import (
-    SalesforceLogin, SalesforceAuthenticationFailed
-)
-
+from simple_salesforce.login import SalesforceLogin
+from simple_salesforce.exceptions import SalesforceAuthenticationFailed
 
 
 class TestSalesforceLogin(unittest.TestCase):

--- a/simple_salesforce/util.py
+++ b/simple_salesforce/util.py
@@ -34,23 +34,3 @@ def date_to_iso8601(date):
         timezone=timezone_str
         ).replace(':', '%3A').replace('+', '%2B')
 
-
-class SalesforceError(Exception):
-    """Base Salesforce API exception"""
-
-    message = u'Unknown error occurred for {url}. Response content: {content}'
-
-    def __init__(self, url, status, resource_name, content):
-        # TODO exceptions don't seem to be using parent constructors at all.
-        # this should be fixed.
-        # pylint: disable=super-init-not-called
-        self.url = url
-        self.status = status
-        self.resource_name = resource_name
-        self.content = content
-
-    def __str__(self):
-        return self.message.format(url=self.url, content=self.content)
-
-    def __unicode__(self):
-        return self.__str__()

--- a/simple_salesforce/util.py
+++ b/simple_salesforce/util.py
@@ -33,4 +33,3 @@ def date_to_iso8601(date):
         tzsign=timezone_sign,
         timezone=timezone_str
         ).replace(':', '%3A').replace('+', '%2B')
-


### PR DESCRIPTION
We were running into the problem where there were individual Exceptions in individual files, and reusing exceptions (for example if there was to be a bulk API python file) would require importing from the single-object API file.

Moving all the exceptions to this file would make the most sense.

A discussed in #143 