### PR TITLE
Deprecated sandbox flag in favor of domain flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
 # command to install dependencies (mock & nose are already installed)
 install:
   - pip install tox
+  - pip install pylint
 # command to run tests
 script: tox
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ python:
 # command to install dependencies (mock & nose are already installed)
 install:
   - pip install tox
-  - pip install pylint
 # command to run tests
 script: tox
 matrix:

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ For example:
     from simple_salesforce import Salesforce
     sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', domain='test')
 
-Note that specifying if you want to use a login domain is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
+Note that specifying if you want to use a domain is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
 
 If you'd like to keep track where your API calls are coming from, simply add ``client_id='My App'`` to your ``Salesforce()`` call.
 
@@ -310,7 +310,7 @@ Additional Features
 
 There are a few helper classes that are used internally and available to you.
 
-Included in them are ``SalesforceLogin``, which takes in a username, password, security token, optional version and optional login domain and returns a tuple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
+Included in them are ``SalesforceLogin``, which takes in a username, password, security token, optional version and optional domain and returns a tuple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
 
 For example, to use SalesforceLogin for a sandbox account you'd use:
 

--- a/README.rst
+++ b/README.rst
@@ -51,14 +51,14 @@ To login using IP-whitelist Organization ID method, simply use your Salesforce u
     from simple_salesforce import Salesforce
     sf = Salesforce(password='password', username='myemail@example.com', organizationId='OrgId')
 
-If you'd like to enter a sandbox, simply add ``login_domain='test'`` to your ``Salesforce()`` call.
+If you'd like to enter a sandbox, simply add ``domain='test'`` to your ``Salesforce()`` call.
 
 For example:
 
 .. code-block:: python
 
     from simple_salesforce import Salesforce
-    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', login_domain='test')
+    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', domain='test')
 
 Note that specifying if you want to use a login domain is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
 
@@ -67,7 +67,7 @@ If you'd like to keep track where your API calls are coming from, simply add ``c
 .. code-block:: python
 
     from simple_salesforce import Salesforce
-    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', client_id='My App', login_domain='test')
+    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', client_id='My App', domain='test')
 
 If you view the API calls in your Salesforce instance by Client Id it will be prefixed with ``RestForce/``, for example ``RestForce/My App``.
 
@@ -321,9 +321,9 @@ For example, to use SalesforceLogin for a sandbox account you'd use:
         username='myemail@example.com.sandbox',
         password='password',
         security_token='token',
-        login_domain='test')
+        domain='test')
 
-Simply leave off the final login_domain if you do not wish to use a sandbox.
+Simply leave off the final domain if you do not wish to use a sandbox.
 
 Also exposed is the ``SFType`` class, which is used internally by the ``__getattr__()`` method in the ``Salesforce()`` class and represents a specific SObject type. ``SFType`` requires ``object_name`` (i.e. ``Contact``), ``session_id`` (an authentication ID), ``sf_instance`` (hostname of your Salesforce instance), and an optional ``sf_version``
 

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ You can find out more regarding the format of the results in the `Official Sales
 
 .. _Official Salesforce.com REST API Documentation: http://www.salesforce.com/us/developer/docs/api_rest/index.htm
 
-Example
+Examples
 -------
 There are two ways to gain access to Salesforce
 
@@ -51,23 +51,23 @@ To login using IP-whitelist Organization ID method, simply use your Salesforce u
     from simple_salesforce import Salesforce
     sf = Salesforce(password='password', username='myemail@example.com', organizationId='OrgId')
 
-If you'd like to enter a sandbox, simply add ``sandbox=True`` to your ``Salesforce()`` call.
+If you'd like to enter a sandbox, simply add ``login_domain='test'`` to your ``Salesforce()`` call.
 
 For example:
 
 .. code-block:: python
 
     from simple_salesforce import Salesforce
-    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', sandbox=True)
+    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', login_domain='test')
 
-Note that specifying if you want to use a sandbox is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
+Note that specifying if you want to use a login domain is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
 
 If you'd like to keep track where your API calls are coming from, simply add ``client_id='My App'`` to your ``Salesforce()`` call.
 
 .. code-block:: python
 
     from simple_salesforce import Salesforce
-    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', sandbox=True, client_id='My App')
+    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', client_id='My App', login_domain='test')
 
 If you view the API calls in your Salesforce instance by Client Id it will be prefixed with ``RestForce/``, for example ``RestForce/My App``.
 
@@ -310,7 +310,7 @@ Additional Features
 
 There are a few helper classes that are used internally and available to you.
 
-Included in them are ``SalesforceLogin``, which takes in a username, password, security token, optional boolean sandbox indicator and optional version and returns a tuple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
+Included in them are ``SalesforceLogin``, which takes in a username, password, security token, optional version and optional login domain and returns a tuple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
 
 For example, to use SalesforceLogin for a sandbox account you'd use:
 
@@ -321,9 +321,9 @@ For example, to use SalesforceLogin for a sandbox account you'd use:
         username='myemail@example.com.sandbox',
         password='password',
         security_token='token',
-        sandbox=True)
+        login_domain='test')
 
-Simply leave off the final ``True`` if you do not wish to use a sandbox.
+Simply leave off the final login_domain if you do not wish to use a sandbox.
 
 Also exposed is the ``SFType`` class, which is used internally by the ``__getattr__()`` method in the ``Salesforce()`` class and represents a specific SObject type. ``SFType`` requires ``object_name`` (i.e. ``Contact``), ``session_id`` (an authentication ID), ``sf_instance`` (hostname of your Salesforce instance), and an optional ``sf_version``
 

--- a/docs/user_guide/additional_features.rst
+++ b/docs/user_guide/additional_features.rst
@@ -3,7 +3,7 @@ Additional Features
 
 There are a few helper classes that are used internally and available to you.
 
-Included in them are ``SalesforceLogin``, which takes in a username, password, security token, optional boolean sandbox indicator and optional version and returns a tuple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
+Included in them are ``SalesforceLogin``, which takes in a username, password, security token, optional version and optional login domain and returns a tuple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
 
 For example, to use SalesforceLogin for a sandbox account you'd use:
 
@@ -14,9 +14,9 @@ For example, to use SalesforceLogin for a sandbox account you'd use:
         username='myemail@example.com.sandbox',
         password='password',
         security_token='token',
-        sandbox=True)
+        login_domain='test')
 
-Simply leave off the final ``True`` if you do not wish to use a sandbox.
+Simply leave off the final login_domain if you do not wish to use a sandbox.
 
 Also exposed is the ``SFType`` class, which is used internally by the ``__getattr__()`` method in the ``Salesforce()`` class and represents a specific SObject type. ``SFType`` requires ``object_name`` (i.e. ``Contact``), ``session_id`` (an authentication ID), ``sf_instance`` (hostname of your Salesforce instance), and an optional ``sf_version``
 

--- a/docs/user_guide/additional_features.rst
+++ b/docs/user_guide/additional_features.rst
@@ -3,7 +3,7 @@ Additional Features
 
 There are a few helper classes that are used internally and available to you.
 
-Included in them are ``SalesforceLogin``, which takes in a username, password, security token, optional version and optional login domain and returns a tuple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
+Included in them are ``SalesforceLogin``, which takes in a username, password, security token, optional version and optional domain and returns a tuple of ``(session_id, sf_instance)`` where `session_id` is the session ID to use for authentication to Salesforce and ``sf_instance`` is the domain of the instance of Salesforce to use for the session.
 
 For example, to use SalesforceLogin for a sandbox account you'd use:
 

--- a/docs/user_guide/additional_features.rst
+++ b/docs/user_guide/additional_features.rst
@@ -14,9 +14,9 @@ For example, to use SalesforceLogin for a sandbox account you'd use:
         username='myemail@example.com.sandbox',
         password='password',
         security_token='token',
-        login_domain='test')
+        domain='test')
 
-Simply leave off the final login_domain if you do not wish to use a sandbox.
+Simply leave off the final domain if you do not wish to use a sandbox.
 
 Also exposed is the ``SFType`` class, which is used internally by the ``__getattr__()`` method in the ``Salesforce()`` class and represents a specific SObject type. ``SFType`` requires ``object_name`` (i.e. ``Contact``), ``session_id`` (an authentication ID), ``sf_instance`` (hostname of your Salesforce instance), and an optional ``sf_version``
 

--- a/docs/user_guide/examples.rst
+++ b/docs/user_guide/examples.rst
@@ -34,23 +34,23 @@ To login using IP-whitelist Organization ID method, simply use your Salesforce u
     from simple_salesforce import Salesforce
     sf = Salesforce(password='password', username='myemail@example.com', organizationId='OrgId')
 
-If you'd like to enter a sandbox, simply add ``sandbox=True`` to your ``Salesforce()`` call.
+If you'd like to enter a sandbox, simply add ``login_domain='test'`` to your ``Salesforce()`` call.
 
 For example:
 
 .. code-block:: python
 
     from simple_salesforce import Salesforce
-    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', sandbox=True)
+    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', login_domain='test')
 
-Note that specifying if you want to use a sandbox is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
+Note that specifying if you want to use a login domain is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
 
 If you'd like to keep track where your API calls are coming from, simply add ``client_id='My App'`` to your ``Salesforce()`` call.
 
 .. code-block:: python
 
     from simple_salesforce import Salesforce
-    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', sandbox=True, client_id='My App')
+    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', client_id='My App', login_domain='test')
 
 If you view the API calls in your Salesforce instance by Client Id it will be prefixed with ``RestForce/``, for example ``RestForce/My App``.
 

--- a/docs/user_guide/examples.rst
+++ b/docs/user_guide/examples.rst
@@ -34,14 +34,14 @@ To login using IP-whitelist Organization ID method, simply use your Salesforce u
     from simple_salesforce import Salesforce
     sf = Salesforce(password='password', username='myemail@example.com', organizationId='OrgId')
 
-If you'd like to enter a sandbox, simply add ``login_domain='test'`` to your ``Salesforce()`` call.
+If you'd like to enter a sandbox, simply add ``domain='test'`` to your ``Salesforce()`` call.
 
 For example:
 
 .. code-block:: python
 
     from simple_salesforce import Salesforce
-    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', login_domain='test')
+    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', domain='test')
 
 Note that specifying if you want to use a login domain is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
 
@@ -50,7 +50,7 @@ If you'd like to keep track where your API calls are coming from, simply add ``c
 .. code-block:: python
 
     from simple_salesforce import Salesforce
-    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', client_id='My App', login_domain='test')
+    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', client_id='My App', domain='test')
 
 If you view the API calls in your Salesforce instance by Client Id it will be prefixed with ``RestForce/``, for example ``RestForce/My App``.
 

--- a/docs/user_guide/examples.rst
+++ b/docs/user_guide/examples.rst
@@ -43,7 +43,7 @@ For example:
     from simple_salesforce import Salesforce
     sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', domain='test')
 
-Note that specifying if you want to use a login domain is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
+Note that specifying if you want to use a domain is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
 
 If you'd like to keep track where your API calls are coming from, simply add ``client_id='My App'`` to your ``Salesforce()`` call.
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -104,8 +104,8 @@ class Salesforce(object):
             if kwargs['sandbox'] is True:
                 login_domain = 'test'
 
-        # Determine if the user passed in the optional version and/or login_domain
-        # kwargs
+        # Determine if the user passed in the optional version and/or
+        # login_domain kwargs
         self.sf_version = version
         self.login_domain = login_domain
         self.session = session or requests.Session()

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -98,14 +98,14 @@ class Salesforce(object):
         """
         if (sandbox is not None) and (domain is not None):
             raise ValueError("Both 'sandbox' and 'domain' arguments were "
-                                "supplied. Either may be supplied, but not "
-                                "both.")
+                             "supplied. Either may be supplied, but not "
+                             "both.")
 
         if sandbox is not None:
             warnings.warn("'sandbox' argument is deprecated. Use "
-                        "'domain' instead. Overriding 'domain' "
-                        "with 'sandbox' value.",
-                        DeprecationWarning)
+                          "'domain' instead. Overriding 'domain' "
+                          "with 'sandbox' value.",
+                          DeprecationWarning)
 
             domain = 'test' if sandbox else 'login'
 

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -56,8 +56,8 @@ def SalesforceLogin(
         if kwargs['sandbox'] is True:
             login_domain = 'test'
 
-    soap_url = 'https://{login_domain}.salesforce.com/'
-               'services/Soap/u/{sf_version}'
+    soap_url = ('https://{login_domain}.salesforce.com/'
+                'services/Soap/u/{sf_version}')
 
     if client_id:
         client_id = "{prefix}/{app_name}".format(

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -21,8 +21,8 @@ import requests
 # pylint: disable=invalid-name,too-many-arguments,too-many-locals
 def SalesforceLogin(
         username=None, password=None, security_token=None,
-        organizationId=None, sandbox=False, sf_version=DEFAULT_API_VERSION,
-        proxies=None, session=None, client_id=None):
+        organizationId=None, sf_version=DEFAULT_API_VERSION,
+        proxies=None, session=None, client_id=None, login_domain='login', **kwargs):
     """Return a tuple of `(session_id, sf_instance)` where `session_id` is the
     session ID to use for authentication to Salesforce and `sf_instance` is
     the domain of the instance of Salesforce to use for the session.
@@ -34,8 +34,7 @@ def SalesforceLogin(
     * security_token -- the security token for the username
     * organizationId -- the ID of your organization
             NOTE: security_token an organizationId are mutually exclusive
-    * sandbox -- True if you want to login to `test.salesforce.com`, False if
-                 you want to login to `login.salesforce.com`.
+    * sandbox -- DEPRECATED: Use login_domain instead.
     * sf_version -- the version of the Salesforce API to use, for example
                     "27.0"
     * proxies -- the optional map of scheme to proxy server
@@ -43,10 +42,19 @@ def SalesforceLogin(
                  enables the use of requets Session features not otherwise
                  exposed by simple_salesforce.
     * client_id -- the ID of this client
+    * login_domain -- The domain to using for logging in. Use common login
+                      domains, such as 'login' or 'test', or named domain.
     """
+    if 'sandbox' in kwargs.keys():
+        warnings.warn('\'sandbox\' argument is deprecated. Use '
+                        '\'login_domain\' instead. Overriding login_domain '
+                        'with sandbox flag.',
+                        DeprecationWarning)
+        login_domain = 'login'
+        if kwargs['sandbox'] is True:
+            login_domain = 'test'
 
-    soap_url = 'https://{domain}.salesforce.com/services/Soap/u/{sf_version}'
-    domain = 'test' if sandbox else 'login'
+    soap_url = 'https://{login_domain}.salesforce.com/services/Soap/u/{sf_version}'
 
     if client_id:
         client_id = "{prefix}/{app_name}".format(
@@ -55,7 +63,7 @@ def SalesforceLogin(
     else:
         client_id = DEFAULT_CLIENT_ID_PREFIX
 
-    soap_url = soap_url.format(domain=domain, sf_version=sf_version)
+    soap_url = soap_url.format(login_domain=login_domain, sf_version=sf_version)
 
     # pylint: disable=E0012,deprecated-method
     username = escape(username)

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -50,14 +50,14 @@ def SalesforceLogin(
     """
     if (sandbox is not None) and (domain is not None):
         raise ValueError("Both 'sandbox' and 'domain' arguments were "
-                            "supplied. Either may be supplied, but not "
-                            "both.")
+                         "supplied. Either may be supplied, but not "
+                         "both.")
 
     if sandbox is not None:
         warnings.warn("'sandbox' argument is deprecated. Use "
-                    "'domain' instead. Overriding 'domain' "
-                    "with 'sandbox' value.",
-                    DeprecationWarning)
+                      "'domain' instead. Overriding 'domain' "
+                      "with 'sandbox' value.",
+                      DeprecationWarning)
 
         domain = 'test' if sandbox else 'login'
 

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     from cgi import escape
 import requests
+import warnings
 
 
 # pylint: disable=invalid-name,too-many-arguments,too-many-locals

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -23,7 +23,8 @@ import warnings
 def SalesforceLogin(
         username=None, password=None, security_token=None,
         organizationId=None, sf_version=DEFAULT_API_VERSION,
-        proxies=None, session=None, client_id=None, login_domain='login', **kwargs):
+        proxies=None, session=None, client_id=None, login_domain='login',
+        **kwargs):
     """Return a tuple of `(session_id, sf_instance)` where `session_id` is the
     session ID to use for authentication to Salesforce and `sf_instance` is
     the domain of the instance of Salesforce to use for the session.
@@ -55,7 +56,8 @@ def SalesforceLogin(
         if kwargs['sandbox'] is True:
             login_domain = 'test'
 
-    soap_url = 'https://{login_domain}.salesforce.com/services/Soap/u/{sf_version}'
+    soap_url = 'https://{login_domain}.salesforce.com/'
+               'services/Soap/u/{sf_version}'
 
     if client_id:
         client_id = "{prefix}/{app_name}".format(
@@ -64,7 +66,8 @@ def SalesforceLogin(
     else:
         client_id = DEFAULT_CLIENT_ID_PREFIX
 
-    soap_url = soap_url.format(login_domain=login_domain, sf_version=sf_version)
+    soap_url = soap_url.format(login_domain=login_domain,
+                               sf_version=sf_version)
 
     # pylint: disable=E0012,deprecated-method
     username = escape(username)

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -33,6 +33,141 @@ class TestSalesforceLogin(unittest.TestCase):
         self.addCleanup(request_patcher.stop)
 
     @responses.activate
+    def test_default_domain_success(self):
+        """Test default domain logic and login"""
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://login.*$'),
+            body=tests.LOGIN_RESPONSE_SUCCESS,
+            status=http.OK
+        )
+        session_state = {
+            'used': False,
+        }
+
+        # pylint: disable=missing-docstring,unused-argument
+        def on_response(*args, **kwargs):
+            session_state['used'] = True
+
+        session = requests.Session()
+        session.hooks = {
+            'response': on_response,
+        }
+        session_id, instance = SalesforceLogin(
+            session=session,
+            username='foo@bar.com',
+            password='password',
+            security_token='token')
+        self.assertTrue(session_state['used'])
+        self.assertEqual(session_id, tests.SESSION_ID)
+        self.assertEqual(instance, urlparse(tests.SERVER_URL).netloc)
+
+    @responses.activate
+    def test_custom_domain_success(self):
+        """Test custom domain login"""
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://testdomain.my.*$'),
+            body=tests.LOGIN_RESPONSE_SUCCESS,
+            status=http.OK
+        )
+        session_state = {
+            'used': False,
+        }
+
+        # pylint: disable=missing-docstring,unused-argument
+        def on_response(*args, **kwargs):
+            session_state['used'] = True
+
+        session = requests.Session()
+        session.hooks = {
+            'response': on_response,
+        }
+        session_id, instance = SalesforceLogin(
+            session=session,
+            username='foo@bar.com',
+            password='password',
+            security_token='token',
+            domain='testdomain.my')
+        self.assertTrue(session_state['used'])
+        self.assertEqual(session_id, tests.SESSION_ID)
+        self.assertEqual(instance, urlparse(tests.SERVER_URL).netloc)
+
+    @responses.activate
+    def test_deprecated_sandbox_disabled_success(self):
+        """Test sandbox argument set to False"""
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://login.*$'),
+            body=tests.LOGIN_RESPONSE_SUCCESS,
+            status=http.OK
+        )
+        session_state = {
+            'used': False,
+        }
+
+        # pylint: disable=missing-docstring,unused-argument
+        def on_response(*args, **kwargs):
+            session_state['used'] = True
+
+        session = requests.Session()
+        session.hooks = {
+            'response': on_response,
+        }
+        session_id, instance = SalesforceLogin(
+            session=session,
+            username='foo@bar.com',
+            password='password',
+            security_token='token',
+            sandbox=False)
+        self.assertTrue(session_state['used'])
+        self.assertEqual(session_id, tests.SESSION_ID)
+        self.assertEqual(instance, urlparse(tests.SERVER_URL).netloc)
+
+    @responses.activate
+    def test_deprecated_sandbox_enabled_success(self):
+        """Test sandbox argument set to True"""
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://test.*$'),
+            body=tests.LOGIN_RESPONSE_SUCCESS,
+            status=http.OK
+        )
+        session_state = {
+            'used': False,
+        }
+
+        # pylint: disable=missing-docstring,unused-argument
+        def on_response(*args, **kwargs):
+            session_state['used'] = True
+
+        session = requests.Session()
+        session.hooks = {
+            'response': on_response,
+        }
+        session_id, instance = SalesforceLogin(
+            session=session,
+            username='foo@bar.com',
+            password='password',
+            security_token='token',
+            sandbox=True)
+        self.assertTrue(session_state['used'])
+        self.assertEqual(session_id, tests.SESSION_ID)
+        self.assertEqual(instance, urlparse(tests.SERVER_URL).netloc)
+
+    def test_domain_sandbox_mutual_exclusion_failure(self):
+        """Test sandbox and domain mutual exclusion"""
+
+        with self.assertRaises(ValueError):
+            SalesforceLogin(
+                username='myemail@example.com.sandbox',
+                password='password',
+                security_token='token',
+                domain='login',
+                sandbox=False
+            )
+
+    @responses.activate
     def test_custom_session_success(self):
         """Test custom session"""
         responses.add(
@@ -75,6 +210,6 @@ class TestSalesforceLogin(unittest.TestCase):
                 username='myemail@example.com.sandbox',
                 password='password',
                 security_token='token',
-                login_domain='test'
+                domain='test'
             )
         self.assertTrue(self.mockrequest.post.called)

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -75,6 +75,6 @@ class TestSalesforceLogin(unittest.TestCase):
                 username='myemail@example.com.sandbox',
                 password='password',
                 security_token='token',
-                sandbox=True
+                login_domain='test',
             )
         self.assertTrue(self.mockrequest.post.called)

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -75,6 +75,6 @@ class TestSalesforceLogin(unittest.TestCase):
                 username='myemail@example.com.sandbox',
                 password='password',
                 security_token='token',
-                login_domain='test',
+                login_domain='test'
             )
         self.assertTrue(self.mockrequest.post.called)


### PR DESCRIPTION
This is useful for cases where the login domain is a custom domain, meaning that
it is neither 'login' nor 'test'. Default is 'login', however, so the default behavior is unchanged. Updated current api appropriately (along with non-fatal deprecation warning), while allowing SalesforceApi class to stay the same.