### PR TITLE
Add method for getting organization limits

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -339,6 +339,18 @@ class Salesforce(object):
         search_string = u'FIND {{{search_string}}}'.format(search_string=search)
         return self.search(search_string)
 
+    def limits(self, **kwargs):
+        """Return the result of a Salesforce request to list Organization
+        limits.
+        """
+        url = self.base_url + 'limits/'
+        result = self._call_salesforce('GET', url, **kwargs)
+
+        if result.status_code != 200:
+            exception_handler(result)
+
+        return result.json(object_pairs_hook=OrderedDict)
+
     # Query Handler
     def query(self, query, **kwargs):
         """Return the result of a Salesforce SOQL query as a dict decoded from

--- a/simple_salesforce/tests/__init__.py
+++ b/simple_salesforce/tests/__init__.py
@@ -49,3 +49,98 @@ LOGIN_RESPONSE_SUCCESS = """<?xml version="1.0" encoding="UTF-8"?>
    </soapenv:Body>
 </soapenv:Envelope>
 """ % (METADATA_URL, SERVER_URL, SESSION_ID)
+
+ORGANIZATION_LIMITS_RESPONSE = {
+    "ConcurrentAsyncGetReportInstances": {
+        "Max": 200,
+        "Remaining": 200
+    },
+    "ConcurrentSyncReportRuns": {
+        "Max": 20,
+        "Remaining": 20
+    },
+    "DailyApiRequests": {
+        "Max": 15000,
+        "Remaining": 14998
+    },
+    "DailyAsyncApexExecutions": {
+        "Max": 250000,
+        "Remaining": 250000
+    },
+    "DailyBulkApiRequests": {
+        "Max": 5000,
+        "Remaining": 5000
+    },
+    "DailyDurableGenericStreamingApiEvents": {
+        "Max": 10000,
+        "Remaining": 10000
+    },
+    "DailyDurableStreamingApiEvents": {
+        "Max": 10000,
+        "Remaining": 10000
+    },
+    "DailyGenericStreamingApiEvents": {
+        "Max": 10000,
+        "Remaining": 10000
+    },
+    "DailyStreamingApiEvents": {
+        "Max": 10000,
+        "Remaining": 10000
+    },
+    "DailyWorkflowEmails": {
+        "Max": 390,
+        "Remaining": 390
+    },
+    "DataStorageMB": {
+        "Max": 5,
+        "Remaining": 5
+    },
+    "DurableStreamingApiConcurrentClients": {
+        "Max": 20,
+        "Remaining": 20
+    },
+    "FileStorageMB": {
+        "Max": 20,
+        "Remaining": 20
+    },
+    "HourlyAsyncReportRuns": {
+        "Max": 1200,
+        "Remaining": 1200
+    },
+    "HourlyDashboardRefreshes": {
+        "Max": 200,
+        "Remaining": 200
+    },
+    "HourlyDashboardResults": {
+        "Max": 5000,
+        "Remaining": 5000
+    },
+    "HourlyDashboardStatuses": {
+        "Max": 999999999,
+        "Remaining": 999999999
+    },
+    "HourlyODataCallout": {
+        "Max": 10000,
+        "Remaining": 9999
+    },
+    "HourlySyncReportRuns": {
+        "Max": 500,
+        "Remaining": 500
+    },
+    "HourlyTimeBasedWorkflow": {
+        "Max": 50,
+        "Remaining": 50
+    },
+    "MassEmail": {
+        "Max": 10,
+        "Remaining": 10
+    },
+    "SingleEmail": {
+        "Max": 15,
+        "Remaining": 15
+    },
+    "StreamingApiConcurrentClients": {
+        "Max": 20,
+        "Remaining": 20
+    }
+}

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -605,3 +605,21 @@ class TestSalesforce(unittest.TestCase):
                              {'api-usage': Usage(25, 5000),
                               'per-app-api-usage': PerAppUsage(17, 250,
                                                                'sample-app')})
+
+    @responses.activate
+    def test_api_limits(self):
+        """Test method for getting Salesforce organization limits"""
+
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*/limits/$'),
+            json=tests.ORGANIZATION_LIMITS_RESPONSE,
+            status=http.OK
+        )
+
+        client = Salesforce.__new__(Salesforce)
+        client.session = requests.Session()
+        client.headers = {}
+        client.base_url = "https://localhost/"
+
+        self.assertEqual(client.limits(), tests.ORGANIZATION_LIMITS_RESPONSE)


### PR DESCRIPTION
I made this for myself and I think it may be useful for someone.

Add a simple method for getting organization limits as described in
https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_limits.htm

This is my first time PR in a open repo, so please be patient if a missed something stupid.