### PR TITLE
multi batch jobs

### DIFF
--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -195,17 +195,19 @@ class SFBulkType(object):
         def worker():
             """ Add batches and wait for network responses (I/O) concurrently
             with worker threads. (there may be a lot of batches)
-
+            
             Arguments: 
             (Workers pull their args from the queue)
-            * data -- Batch-sized (<=10000 records) slice of list of dict, see line 185
+            * data -- Batch-sized (<=10000 records) slice of 
+            list of dict, see line 185
             """
             while True:
                 data = queue.get()
                 if data is None: break
                 batch = self._add_batch(job_id=job['id'], data=data,
                                         operation=operation)
-                status = self._get_batch(job_id=batch['jobId'], batch_id=batch['id'])['state']
+                status = self._get_batch(job_id=batch['jobId'],
+                                        batch_id=batch['id'])['state']
 
                 while status not in ('Completed', 'Failed', 'Not Processed'):
                     sleep(wait)
@@ -213,12 +215,13 @@ class SFBulkType(object):
                                              batch_id=batch['id'])['state']
 
                 batch_results = self._get_batch_results(job_id=batch['jobId'],
-                                            batch_id=batch['id'], operation=operation)
+                                    batch_id=batch['id'], operation=operation)
                 results.append(batch_results)
                 queue.task_done()
 
         threads = [Thread(target=worker) for _ in range(num_threads)]
-        for thread in threads: thread.start()
+        for thread in threads:
+            thread.start()
 
         for j, i in enumerate(range(num_batches), 1):
             queue.put(data[i * 10000:j * 10000])
@@ -226,7 +229,8 @@ class SFBulkType(object):
         queue.join()
         for i in range(num_threads):
             queue.put(None)
-        for thread in threads: thread.join()
+        for thread in threads:
+            thread.join()
 
         self._close_job(job_id=job['id'])
         return results

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -191,9 +191,7 @@ class SFBulkType(object):
                 data = q.get()
                 if batch is None:
                     break
-                batch = self._add_batch(job_id=job['id'],
-                                        data=data,
-                                        operation=operation)
+                batch = self._add_batch(job_id=job['id'], data=data, operation=operation)
                 batches.append(batch)
                 q.task_done()
 
@@ -207,16 +205,18 @@ class SFBulkType(object):
 
         self._close_job(job_id=job['id'])
 
-        batches_pending = [ self._get_batch(batch['jobId'], batch['id']) for batch in batches 
+        batches_pending = [ self._get_batch(batch['jobId'], batch['id'], operation=operation) for batch in batches 
                     if batch['state'] not in ('Completed', 'Failed', 'Not Processed') ]
         while batches_pending:
-            batches_pending = [ self._get_batch(batch['jobId'], batch['id']) for batch in pending
+            batches_pending = [ self._get_batch(batch['jobId'], batch['id'], operation=operation) for batch in pending
                         if batch['state'] not in ('Completed', 'Failed', 'Not Processed') ]
             sleep(wait)
 
-        results = map(lambda batch: { batch['id']: self._get_batch_results(job_id=batch['jobId'],
-                                                                           batch_id=batch['id'],
-                                                                           operation=operation) }, batches)
+        results = [ 
+                    self._get_batch_results(job_id=batch['jobId'], batch_id=batch['id'], operation=operation) 
+                    for batch 
+                    in batches
+                  ]
         return results
 
     # _bulk_operation wrappers to expose supported Salesforce bulk operations

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -195,24 +195,22 @@ class SFBulkType(object):
         def worker():
             """ Add batches and wait for network responses (I/O) concurrently
             with worker threads. (there may be a lot of batches)
-            
-            Arguments: 
+            Arguments:
             (Workers pull their args from the queue)
-            * data -- Batch-sized (<=10000 records) slice of 
+            * data -- Batch-sized (<=10000 records) slice of
             list of dict, see line 185
             """
             while True:
                 data = queue.get()
-                if data is None: break
+                if data is None:
+                    break
                 batch = self._add_batch(job_id=job['id'], data=data,
                                         operation=operation)
-                status = self._get_batch(job_id=batch['jobId'],
-                                        batch_id=batch['id'])['state']
 
-                while status not in ('Completed', 'Failed', 'Not Processed'):
+                while batch['state'] not in ('Completed', 'Failed', 'Not Processed'):
                     sleep(wait)
-                    status = self._get_batch(job_id=batch['jobId'],
-                                             batch_id=batch['id'])['state']
+                    batch = self._get_batch(job_id=batch['jobId'],
+                                             batch_id=batch['id'])
 
                 batch_results = self._get_batch_results(job_id=batch['jobId'],
                                     batch_id=batch['id'], operation=operation)

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -193,13 +193,7 @@ class SFBulkType(object):
                                external_id_field=external_id_field)
 
         def worker():
-            """ Add batches and wait for network responses (I/O) concurrently
-            with worker threads. (there may be a lot of batches)
-            Arguments:
-            (Workers pull their args from the queue)
-            * data -- Batch-sized (<=10000 records) slice of
-            list of dict, see line 185
-            """
+            """ Add batches to concurrent worker threads"""
             while True:
                 data = queue.get()
                 if data is None:

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -14,7 +14,6 @@ except ImportError:
 
 from threading import Thread
 from multiprocessing import cpu_count
-from math import ceil
 import json
 import requests
 from time import sleep

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -9,7 +9,7 @@ except ImportError:
 
 try:
     from queue import Queue
-except: ImportError:
+except ImportError:
     # Python < 3.x
     from Queue import Queue
 

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -201,7 +201,8 @@ class SFBulkType(object):
                 batch = self._add_batch(job_id=job['id'], data=data,
                                         operation=operation)
 
-                while batch['state'] not in ('Completed', 'Failed', 'Not Processed'):
+                while batch['state'] not in 
+                  ('Completed', 'Failed', 'Not Processed'):
                     sleep(wait)
                     batch = self._get_batch(job_id=batch['jobId'],
                                              batch_id=batch['id'])

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -213,11 +213,11 @@ class SFBulkType(object):
         for thread in threads:
             thread.start()
 
-        for n in range(0, len(data), 10000):
-            queue.put(data[n:n + 10000])
+        for i in range(0, len(data), 10000):
+            queue.put(data[i:i + 10000])
 
         queue.join()
-        for i in range(cpu_count()):
+        for _ in range(cpu_count()):
             queue.put(None)
         for thread in threads:
             thread.join()

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -205,17 +205,18 @@ class SFBulkType(object):
 
         self._close_job(job_id=job['id'])
 
-        batches_pending = [ self._get_batch(batch['jobId'], batch['id'], operation=operation) for batch in batches 
-                    if batch['state'] not in ('Completed', 'Failed', 'Not Processed') ]
+        batches_pending = [ self._get_batch(batch['jobId'], batch['id'], operation=operation) 
+                            for batch in batches 
+                            if batch['state'] not in ('Completed', 'Failed', 'Not Processed') ]
         while batches_pending:
-            batches_pending = [ self._get_batch(batch['jobId'], batch['id'], operation=operation) for batch in pending
-                        if batch['state'] not in ('Completed', 'Failed', 'Not Processed') ]
+            batches_pending = [ self._get_batch(batch['jobId'], batch['id'], operation=operation)
+                                for batch in pending
+                                if batch['state'] not in ('Completed', 'Failed', 'Not Processed') ]
             sleep(wait)
 
         results = [ 
                     self._get_batch_results(job_id=batch['jobId'], batch_id=batch['id'], operation=operation) 
-                    for batch 
-                    in batches
+                    for batch in batches
                   ]
         return results
 

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -214,10 +214,8 @@ class SFBulkType(object):
                                 if batch['state'] not in ('Completed', 'Failed', 'Not Processed') ]
             sleep(wait)
 
-        results = [ 
-                    self._get_batch_results(job_id=batch['jobId'], batch_id=batch['id'], operation=operation) 
-                    for batch in batches
-                  ]
+        results = [ self._get_batch_results(job_id=batch['jobId'], batch_id=batch['id'], operation=operation) 
+                    for batch in batches ]
         return results
 
     # _bulk_operation wrappers to expose supported Salesforce bulk operations

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -167,8 +167,8 @@ class SFBulkType(object):
 
         return result.json()
 
-    #pylint: disable=R0913
-     def _bulk_operation(self, object_name, operation, data,
+     #pylint: disable=R0913
+    def _bulk_operation(self, object_name, operation, data,
                         external_id_field=None, wait=5):
         """ String together helper functions to create a complete
         end-to-end bulk API request

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -201,8 +201,8 @@ class SFBulkType(object):
                 batch = self._add_batch(job_id=job['id'], data=data,
                                         operation=operation)
 
-                while batch['state'] not in 
-                  ('Completed', 'Failed', 'Not Processed'):
+                while batch['state'] not in ('Completed', 'Failed',
+                                              'Not Processed'):
                     sleep(wait)
                     batch = self._get_batch(job_id=batch['jobId'],
                                              batch_id=batch['id'])

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -2,7 +2,6 @@
 
 try:
     from collections import OrderedDict
-    from queue import Queue
 except ImportError:
     # Python < 2.7
     from ordereddict import OrderedDict


### PR DESCRIPTION
When using bulk api, split records into batches containing <= 10000 records, and associate these with a single job