### PR TITLE
rm python 3.3 from travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ script: tox
 matrix:
   fast_finish: true
   allow_failures:
+    # pylint 1.8.2 dropped support for python 3.3
+    - python: "3.3"
     # Python 3.2 doesn't appear to work. With 3.3 and 3.4 in the world this
     # probably isn't a priority, but lets keep an eye on it anyways
     - python: "3.2"


### PR DESCRIPTION
Latest version of pylint drops support for python 3.3. Updating .travis.yml to allow failures.