### PR TITLE
providing the ability to add more args like `verify`

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -625,7 +625,7 @@ class SFType(object):
         )
         return result.json(object_pairs_hook=OrderedDict)
 
-    def upsert(self, record_id, data, raw_response=False, headers=None):
+    def upsert(self, record_id, data, raw_response=False, headers=None, **kwargs):
         """Creates or updates an SObject using a PATCH to
         `.../{object_name}/{record_id}`.
 
@@ -645,7 +645,7 @@ class SFType(object):
         """
         result = self._call_salesforce(
             method='PATCH', url=urljoin(self.base_url, record_id),
-            data=json.dumps(data), headers=headers
+            data=json.dumps(data), headers=headers, **kwargs
         )
         return self._raw_response(result, raw_response)
 


### PR DESCRIPTION
This PR intends to provide more options (like `verify`) to the `upsert` method so that they could be passed to the [`request` method](https://github.com/simple-salesforce/simple-salesforce/blob/master/simple_salesforce/api.py#L437) to be able to find the right `cacert.pem` file

Reason: The newer version (2.18.4) of python requests has changed the way cacert is verified.
So, it can't implicitly verify the cert from the path it is looking at. It fails with this error -
```python
IOError: Could not find a suitable TLS CA certificate bundle, invalid path: /<path>/.pyenv/virtualenvs/starscream/2.7.11/lib/python2.7/site-packages/requests/cacert.pem
```

This can be changed by explicitly telling it where to look for the cert using something like this - 
```
import certifi  # Importing https://pypi.python.org/pypi/certifi
upsert(record_id, data, verify=certifi.where())  # <<<----- this points it to the cert
```