### PR TITLE
Improve PyPI releases done via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,14 @@ deploy:
   # Allow travis-ci to deploy new tags to PyPI
   provider: pypi
   user: simple-salesforce
+  skip_cleanup: true
   password:
     secure: "J7qjXx9tmsjZQIyLMRK3roEV1+6GmmME34UrdomlipNixc5MELQLZP2gUThIOf3++824AGX9Dgkq0h5YyAwnawXq7QQFcsOOcz8evcE9v6nVc7EEKCOvIeZ7dXHTAk1a+nLH4I7S5t4B+2bpLI5W3AyHxdpD8TrbZ28tFtuQ2e4="
   distributions: "sdist bdist_wheel"
   on:
+    python: '3.6'
     tags: true
-    all_branches: true
+    branch: master
     repo: simple-salesforce/simple-salesforce
 env:
   - TOXENV=unit


### PR DESCRIPTION
This PR

- will skip cleanup of build artifacts
- will only release to PyPi when a new release is cut for master branch
- limits pypi releases to only being performed for python3.6