### PR TITLE
fix: exception thrown when salesforce returns 204

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -303,7 +303,10 @@ class Salesforce(object):
         url = self.base_url + path
         result = self._call_salesforce(method, url, name=path, params=params,
                                        **kwargs)
-
+        
+        if result.status_code == 204:
+            return None
+        
         json_result = result.json(object_pairs_hook=OrderedDict)
         if len(json_result) == 0:
             return None


### PR DESCRIPTION
exception thrown when salesforce returns 204.
this happens when doing PATCH request in record field because reponse is empty string and cant be 
serialized
result.json(object_pairs_hook=OrderedDict)