### PR TITLE
Supporting non-json REST endpoints

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -289,7 +289,9 @@ class Salesforce(object):
 
     # Generic Rest Function
     def restful(self, path, params=None, method='GET', **kwargs):
-        """Allows you to make a direct REST call if you know the path
+        """Allows you to make a direct REST call if you know the path.
+        If `Content-Type: application/json` in response, function will return a JSON-parsed OrderedDict.
+        For all other cases the raw content body is returned, e.g., binary data.
 
         Arguments:
 
@@ -303,12 +305,11 @@ class Salesforce(object):
         url = self.base_url + path
         result = self._call_salesforce(method, url, name=path, params=params,
                                        **kwargs)
-
-        json_result = result.json(object_pairs_hook=OrderedDict)
-        if len(json_result) == 0:
-            return None
-
-        return json_result
+        if 'Content-Type' in result.headers and 'application/json' in result.headers['Content-Type'].split(';'):
+            json_result = result.json(object_pairs_hook=OrderedDict)
+            return None if len(json_result) == 0 else json_result
+        else:
+            return result.content
 
     # Search Functions
     def search(self, search):

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -301,8 +301,8 @@ class Salesforce(object):
         * method: HTTP request method, default GET
         * other arguments supported by requests.request (e.g. json, timeout)
         """
-
-        url = self.base_url + path
+        base_regex = '\/*services\/data\/v[0-9]{2}.[0-9]{1,}\/'
+        url = self.base_url + re.sub(base_regex, '', path)
         result = self._call_salesforce(method, url, name=path, params=params,
                                        **kwargs)
         if 'Content-Type' in result.headers and 'application/json' in result.headers['Content-Type'].split(';'):


### PR DESCRIPTION
When entering a rest URL in the `restful` function, it automatically returns the parsed json response. For downloading files from Salesforce, e.g., _ContentDocumentVersion_, the response is of `Content-Type: application/octet-stream` (interestingly, the real value in the response header from Salesforce is _application/octetstream_, in contrast to their documentation).

The changed `restful` function now reads the _Content-Type_ value and parses the json for `Content-Type: application/json` and returns an unparsed response for all other _Content-Type_ values.

When querying ContentDocumentVersion, the response from Salesforce is a REST path which includes the `/services/data/vXX.X/` prefix. To provide a fluent usage of simple-salesforce with other applications, the `restful` function now accepts the prefix, and removes it by using a regex.