### PR TITLE
Allow additional headers for Salesforce._call_salesforce

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -471,8 +471,12 @@ class Salesforce(object):
 
         Returns a `requests.result` object.
         """
+        headers = self.headers.copy()
+        additional_headers = kwargs.pop('headers', dict())
+        headers.update(additional_headers)
+
         result = self.session.request(
-            method, url, headers=self.headers, **kwargs)
+            method, url, headers=headers, **kwargs)
 
         if result.status_code >= 300:
             exception_handler(result, name=name)

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -49,7 +49,7 @@ PerAppUsage = namedtuple('PerAppUsage', 'used total name')
 
 
 # pylint: disable=too-many-instance-attributes
-class Salesforce:
+class Salesforce(object):
     """Salesforce Instance
 
     An instance of Salesforce is a handy way to wrap a Salesforce session
@@ -529,7 +529,7 @@ class Salesforce:
 
         return result
 
-class SFType:
+class SFType(object):
     """An interface to a specific type of SObject"""
 
     # pylint: disable=too-many-arguments

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -49,7 +49,7 @@ PerAppUsage = namedtuple('PerAppUsage', 'used total name')
 
 
 # pylint: disable=too-many-instance-attributes
-class Salesforce(object):
+class Salesforce:
     """Salesforce Instance
 
     An instance of Salesforce is a handy way to wrap a Salesforce session
@@ -529,7 +529,7 @@ class Salesforce(object):
 
         return result
 
-class SFType(object):
+class SFType:
     """An interface to a specific type of SObject"""
 
     # pylint: disable=too-many-arguments

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -12,7 +12,7 @@ from time import sleep
 from simple_salesforce.util import call_salesforce
 
 
-class SFBulkHandler(object):
+class SFBulkHandler:
     """ Bulk API request handler
     Intermediate class which allows us to use commands,
      such as 'sf.bulk.Contacts.insert(...)'
@@ -51,7 +51,7 @@ class SFBulkHandler(object):
         return SFBulkType(object_name=name, bulk_url=self.bulk_url,
                           headers=self.headers, session=self.session)
 
-class SFBulkType(object):
+class SFBulkType:
     """ Interface to Bulk/Async API functions"""
 
     def __init__(self, object_name, bulk_url, headers, session):

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -12,7 +12,7 @@ from time import sleep
 from simple_salesforce.util import call_salesforce
 
 
-class SFBulkHandler:
+class SFBulkHandler(object):
     """ Bulk API request handler
     Intermediate class which allows us to use commands,
      such as 'sf.bulk.Contacts.insert(...)'
@@ -51,7 +51,7 @@ class SFBulkHandler:
         return SFBulkType(object_name=name, bulk_url=self.bulk_url,
                           headers=self.headers, session=self.session)
 
-class SFBulkType:
+class SFBulkType(object):
     """ Interface to Bulk/Async API functions"""
 
     def __init__(self, object_name, bulk_url, headers, session):


### PR DESCRIPTION
Relatively simple fix to allow the `_call_salesforce()` method of the `Salesforce` class to accept additional headers, similar to how the method can accept them for the `SFType` Class.