### PR TITLE
add ability to pass the file parameter to POST request for creating an Attachment

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -34,6 +34,7 @@ except ImportError:
 #pylint: disable=invalid-name
 logger = logging.getLogger(__name__)
 
+
 def _warn_request_deprecation():
     """Deprecation for (Salesforce/SFType).request attribute"""
     warnings.warn(

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -660,6 +660,9 @@ class SFType(object):
         * data -- a dict of the data to create the SObject from. It will be
                   JSON-encoded before being transmitted.
         * headers -- a dict with additional request headers.
+        * files -- a dict of the data to create the SObject from. It is used
+                   for multipart uploads using the files parameter to
+                   requests.request
         """
         result = None
         if files:

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -795,7 +795,7 @@ class SFType(object):
         }
         additional_headers = kwargs.pop('headers', dict())
         headers.update(additional_headers or dict())
-        if additional_headers.get('Content-Type') == '':
+        if additional_headers and additional_headers.get('Content-Type') == '':
             headers.pop('Content-Type')
         result = self.session.request(method, url, headers=headers, **kwargs)
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -34,7 +34,6 @@ except ImportError:
 #pylint: disable=invalid-name
 logger = logging.getLogger(__name__)
 
-
 def _warn_request_deprecation():
     """Deprecation for (Salesforce/SFType).request attribute"""
     warnings.warn(
@@ -650,7 +649,7 @@ class SFType(object):
         )
         return result.json(object_pairs_hook=OrderedDict)
 
-    def create(self, data, headers=None):
+    def create(self, data, headers=None, files=None):
         """Creates a new SObject using a POST to `.../{object_name}/`.
 
         Returns a dict decoded from the JSON payload returned by Salesforce.
@@ -661,10 +660,17 @@ class SFType(object):
                   JSON-encoded before being transmitted.
         * headers -- a dict with additional request headers.
         """
-        result = self._call_salesforce(
-            method='POST', url=self.base_url,
-            data=json.dumps(data), headers=headers
-        )
+        result = None
+        if files:
+            result = self._call_salesforce(
+                method='POST', url=self.base_url,
+                files=files, headers=headers
+            )
+        else:
+            result = self._call_salesforce(
+                method='POST', url=self.base_url,
+                data=json.dumps(data), headers=headers
+            )
         return result.json(object_pairs_hook=OrderedDict)
 
     def upsert(self, record_id, data, raw_response=False, headers=None):
@@ -788,6 +794,8 @@ class SFType(object):
         }
         additional_headers = kwargs.pop('headers', dict())
         headers.update(additional_headers or dict())
+        if additional_headers.get('Content-Type') == '':
+            headers.pop('Content-Type')
         result = self.session.request(method, url, headers=headers, **kwargs)
 
         if result.status_code >= 300:


### PR DESCRIPTION
and also remove the Content-Type header.

This is required in order to upload an attachment using a multipart upload.

To upload an attachment /tmp/image.png, we need to make the following request:

```
files = {"Body":('image.png',open('/tmp/image.png', 'rb'), 'image/png'),
            "entity_document":(None, json.dumps({"Name":"image.png"}), "application/json")}

r = session.request('POST', 'https://my.salesforce.instance/services/data/v38.0/sobjects/Attachment/', 
                      headers={"X-header-1":"bearer token"}, 
                      files=files
                     )
```

Currently this is not possible because all create requests do a POST with the data parameter, and also the 'Content-Type: application/json' header.

I allow a new parameter 'file', and also allow 'Content-Type' header to not be passed. When the 'file' parameter is passed to session.request, it creates its own multi-part header, with the correct separator. I.e.
```
Content-Type: multipart/form-data; boundary=6fcba61d5e6b467ba8d5983c120cfabf
```
