### PR TITLE
fixed sandbox authentication syntax in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,14 +51,14 @@ To login using IP-whitelist Organization ID method, simply use your Salesforce u
     from simple_salesforce import Salesforce
     sf = Salesforce(password='password', username='myemail@example.com', organizationId='OrgId')
 
-If you'd like to enter a sandbox, simply add ``domain='test'`` to your ``Salesforce()`` call.
+If you'd like to enter a sandbox, simply add ``sandbox=True`` to your ``Salesforce()`` call.
 
 For example:
 
 .. code-block:: python
 
     from simple_salesforce import Salesforce
-    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', domain='test')
+    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', sandbox=True)
 
 Note that specifying if you want to use a domain is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
 
@@ -67,7 +67,7 @@ If you'd like to keep track where your API calls are coming from, simply add ``c
 .. code-block:: python
 
     from simple_salesforce import Salesforce
-    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', client_id='My App', domain='test')
+    sf = Salesforce(username='myemail@example.com.sandbox', password='password', security_token='token', client_id='My App', sandbox=True)
 
 If you view the API calls in your Salesforce instance by Client Id it will be prefixed with ``RestForce/``, for example ``RestForce/My App``.
 
@@ -328,7 +328,7 @@ For example, to use SalesforceLogin for a sandbox account you'd use:
         username='myemail@example.com.sandbox',
         password='password',
         security_token='token',
-        domain='test')
+        sandbox=True)
 
 Simply leave off the final domain if you do not wish to use a sandbox.
 


### PR DESCRIPTION
Changed references in the readme from `domain='test'` to `sandbox=True`.