### PR TITLE
added timeout option

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -60,7 +60,8 @@ class Salesforce(object):
             self, username=None, password=None, security_token=None,
             session_id=None, instance=None, instance_url=None,
             organizationId=None, sandbox=None, version=DEFAULT_API_VERSION,
-            proxies=None, session=None, client_id=None, domain=None):
+            proxies=None, session=None, client_id=None, domain=None,
+            timeout=None):
         """Initialize the instance with the given parameters.
 
         Available kwargs
@@ -94,7 +95,7 @@ class Salesforce(object):
         * session -- Custom requests session, created in calling code. This
                      enables the use of requests Session features not otherwise
                      exposed by simple_salesforce.
-
+        * timeout -- the global timeout to use, in seconds, for each request
         """
         if (sandbox is not None) and (domain is not None):
             raise ValueError("Both 'sandbox' and 'domain' arguments were "
@@ -196,6 +197,7 @@ class Salesforce(object):
                                  version=self.sf_version))
 
         self.api_usage = {}
+        self.timeout = timeout
 
     def describe(self):
         """Describes all available objects
@@ -474,6 +476,9 @@ class Salesforce(object):
         headers = self.headers.copy()
         additional_headers = kwargs.pop('headers', dict())
         headers.update(additional_headers)
+
+        if 'timeout' not in kwargs and self.timeout is not None:
+            kwargs['timeout'] = self.timeout
 
         result = self.session.request(
             method, url, headers=headers, **kwargs)


### PR DESCRIPTION
The default timeout option for requests is None, so that if salesforce is down the request will continue indefinitely.  This lets us specify a default timeout for the request, like:

sf = simple_salesforce.Salesforce('username', 'password', 'token', timeout=30)

So that all requests for this `sf` object will use the default timeout of 30.  This only uses the default timeout on Salesforce._call_salesforce() if `timeout` was note passed as a parameter, and if a default timeout was specified

