### PR TITLE
Updating the requests lib to version 2.22.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,21 +30,21 @@ setup(
     author_email=about['__author_email__'],
     maintainer=about['__maintainer__'],
     maintainer_email=about['__maintainer_email__'],
-    packages=['simple_salesforce',],
+    packages=['simple_salesforce'],
     url=about['__url__'],
     license=about['__license__'],
     description=about['__description__'],
     long_description=textwrap.dedent(open('README.rst', 'r').read()),
 
     install_requires=[
-        'requests[security]'
+        'requests>=2.22.0'
     ] + pyver_install_requires,
     tests_require=[
         'nose>=1.3.0',
         'pytz>=2014.1.1',
         'responses>=0.5.1',
     ] + pyver_tests_require,
-    test_suite = 'nose.collector',
+    test_suite='nose.collector',
 
     keywords=about['__keywords__'],
     classifiers=[


### PR DESCRIPTION
Why?
`The urllib3 library before 1.24.2 for Python mishandles certain cases where the desired set of CA certificates is different from the OS store of CA certificates, which results in SSL connections succeeding in situations where a verification failure is the correct outcome. This is related to use of the ssl_context, ca_certs, or ca_certs_dir argument. `

https://nvd.nist.gov/vuln/detail/CVE-2019-11324
https://github.com/urllib3/urllib3/compare/a6ec68a...1efadf4

The Requests(2.22.0) lib uses:
`urllib3>=1.21.1,<1.26,!=1.25.0,!=1.25.1`
https://github.com/kennethreitz/requests/blob/master/setup.py#L47
