### PR TITLE
Enable testing on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "pypy"
 # command to install dependencies (mock & nose are already installed)
 install:


### PR DESCRIPTION
We intend to use this library in a 3.7 app. It would be great if the library could also be tested for Python 3.7 compatibility going forward.