### PR TITLE
Added check for data equal None in apexecute()

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -456,7 +456,8 @@ class Salesforce(object):
             method,
             self.apex_url + action,
             name="apexexcute",
-            data=json.dumps(data), **kwargs
+            data=json.dumps(data) if data is not None else None,
+            **kwargs
         )
         try:
             response_content = result.json()


### PR DESCRIPTION
Simple fix to allow the apexecute() method of the Salesforce class to accept GET requests (without data).