### PR TITLE
Lazy loading

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ v0.75
 Features
 --------
 - [305] Support for JWT Bearer Token workflow
+- [TODO] Ability to load large results lazily (query_all_iter)
 
 
 v0.73.4

--- a/CHANGES
+++ b/CHANGES
@@ -18,7 +18,7 @@ v0.75
 Features
 --------
 - [305] Support for JWT Bearer Token workflow
-- [TODO] Ability to load large results lazily (query_all_iter)
+- [354] Ability to load large results lazily (query_all_iter)
 
 
 v0.73.4

--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,14 @@ As a convenience, to retrieve all of the results in a single local method call u
 
     sf.query_all("SELECT Id, Email FROM Contact WHERE LastName = 'Jones'")
 
+While ``query_all`` materializes the whole result into a Python list, ``query_all_iter`` returns an iterator, which allows you to lazily process each element separately
+
+.. code-block:: python
+
+    data = sf.query_all_iter("SELECT Id, Email FROM Contact WHERE LastName = 'Jones'")
+    for row in data:
+      process(row)
+
 SOSL queries are done via:
 
 .. code-block:: python

--- a/docs/user_guide/queries.rst
+++ b/docs/user_guide/queries.rst
@@ -22,6 +22,14 @@ As a convenience, to retrieve all of the results in a single local method call u
 
     sf.query_all("SELECT Id, Email FROM Contact WHERE LastName = 'Jones'")
 
+While ``query_all`` materializes the whole result into a Python list, ``query_all_iter`` returns an iterator, which allows you to lazily process each element separately
+
+.. code-block:: python
+
+    data = sf.query_all_iter("SELECT Id, Email FROM Contact WHERE LastName = 'Jones'")
+    for row in data:
+      process(row)
+
 SOSL queries are done via:
 
 .. code-block:: python

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -415,7 +415,8 @@ class Salesforce:
 
         result = self.query(query, include_deleted=include_deleted, **kwargs)
         while True:
-            yield from result['records']
+            for record in result['records']:
+                yield record
             # fetch next batch if we're not done else break out of loop
             if not result['done']:
                 result = self.query_more(result['nextRecordsUrl'],

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -441,11 +441,13 @@ class Salesforce:
         * include_deleted -- True if the query should include deleted records.
         """
 
-        records_lazy = self.query_all_iter(query, include_deleted=include_deleted, **kwargs)
+        records = self.query_all_iter(query, include_deleted=include_deleted,
+                                      **kwargs)
         all_records = list(records_lazy)
         return {
             'records': all_records,
-            # TODO: is this not returned any more? if it is, we'll need to fix tests
+            # TODO: is this not returned any more? if it is, we'll need
+            # to fix tests
             # 'totalSize': len(all_records),
             'done': True,
         }

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -401,10 +401,9 @@ class Salesforce:
         using `query_all_iter`, only materializing the returned iterator to
         maintain backwards compatibility.
 
-        The one difference from `query_all` (apart from being lazy) is that
-        we don't return the totalSize here, because we'd have to return it
-        alongside the data iterator, which would lead to a clunky API.
-        # TODO: not sure about this paragraph above, will check against SFDC
+        The one big difference from `query_all` (apart from being lazy) is that
+        we don't return a dictionary with `totalSize` and `done` here,
+        we only return the records in an iterator.
 
         Arguments
 
@@ -446,9 +445,7 @@ class Salesforce:
         all_records = list(records)
         return {
             'records': all_records,
-            # TODO: is this not returned any more? if it is, we'll need
-            # to fix tests
-            # 'totalSize': len(all_records),
+            'totalSize': len(all_records),
             'done': True,
         }
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -443,7 +443,7 @@ class Salesforce:
 
         records = self.query_all_iter(query, include_deleted=include_deleted,
                                       **kwargs)
-        all_records = list(records_lazy)
+        all_records = list(records)
         return {
             'records': all_records,
             # TODO: is this not returned any more? if it is, we'll need

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -392,6 +392,37 @@ class Salesforce:
 
         return result.json(object_pairs_hook=OrderedDict)
 
+    def query_all_iter(self, query, include_deleted=False, **kwargs):
+        """This is a lazy alternative to `query_all` - it does not construct
+        the whole result set into one container, but returns objects from each
+        page it retrieves from the API.
+
+        Since `query_all` has always been eagerly executed, we reimplemented it
+        using `query_all_iter`, only materializing the returned iterator to
+        maintain backwards compatibility.
+
+        The one difference from `query_all` (apart from being lazy) is that
+        we don't return the totalSize here, because we'd have to return it
+        alongside the data iterator, which would lead to a clunky API.
+        # TODO: not sure about this paragraph above, will check against SFDC
+
+        Arguments
+
+        * query -- the SOQL query to send to Salesforce, e.g.
+                   SELECT Id FROM Lead WHERE Email = "waldo@somewhere.com"
+        * include_deleted -- True if the query should include deleted records.
+        """
+
+        result = self.query(query, include_deleted=include_deleted, **kwargs)
+        while True:
+            yield from result['records']
+            # fetch next batch if we're not done else break out of loop
+            if not result['done']:
+                result = self.query_more(result['nextRecordsUrl'],
+                                         identifier_is_url=True)
+            else:
+                return
+
     def query_all(self, query, include_deleted=False, **kwargs):
         """Returns the full set of results for the `query`. This is a
         convenience
@@ -409,20 +440,15 @@ class Salesforce:
         * include_deleted -- True if the query should include deleted records.
         """
 
-        result = self.query(query, include_deleted=include_deleted, **kwargs)
-        all_records = []
+        records_lazy = self.query_all_iter(query, include_deleted=include_deleted, **kwargs)
+        all_records = list(records_lazy)
+        return {
+            'records': all_records,
+            # TODO: is this not returned any more? if it is, we'll need to fix tests
+            # 'totalSize': len(all_records),
+            'done': True,
+        }
 
-        while True:
-            all_records.extend(result['records'])
-            # fetch next batch if we're not done else break out of loop
-            if not result['done']:
-                result = self.query_more(result['nextRecordsUrl'],
-                                         identifier_is_url=True)
-            else:
-                break
-
-        result['records'] = all_records
-        return result
 
     def apexecute(self, action, method='GET', data=None, **kwargs):
         """Makes an HTTP request to an APEX REST endpoint

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -724,7 +724,8 @@ class TestSalesforce(unittest.TestCase):
             responses.GET,
             re.compile(r'^https://.*/queryAll/\?q=SELECT\+ID\+FROM\+Account$'),
             body='{"records": [{"ID": "1"}], "done": false, "nextRecordsUrl": '
-                 '"https://example.com/queryAll/next-records-id", "totalSize": 2}',
+                 '"https://example.com/queryAll/next-records-id",'
+                 '"totalSize": 2}',
             status=http.OK)
         responses.add(
             responses.GET,

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -660,6 +660,33 @@ class TestSalesforce(unittest.TestCase):
         self.assertEqual(result, {})
 
     @responses.activate
+    def test_query_all_iter(self):
+        """
+        Test that we get data only once we ask for them (lazily).
+        """
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*/query/\?q=SELECT\+ID\+FROM\+Account$'),
+            body='{"records": [{"ID": "1"}], "done": false, "nextRecordsUrl": '
+                 '"https://example.com/query/next-records-id"}',
+            status=http.OK)
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*/query/next-records-id$'),
+            body='{"records": [{"ID": "2"}], "done": true}',
+            status=http.OK)
+        session = requests.Session()
+        client = Salesforce(session_id=tests.SESSION_ID,
+                            instance_url=tests.SERVER_URL,
+                            session=session)
+
+        result = client.query_all_iter('SELECT ID FROM Account')
+        self.assertEqual(next(result), OrderedDict([(u'ID', u'1')]))
+        self.assertEqual(next(result), OrderedDict([(u'ID', u'2')]))
+        with self.assertRaises(StopIteration):
+            next(result)
+
+    @responses.activate
     def test_query_all(self):
         """
         Test that we query and fetch additional result sets automatically.

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -668,12 +668,12 @@ class TestSalesforce(unittest.TestCase):
             responses.GET,
             re.compile(r'^https://.*/query/\?q=SELECT\+ID\+FROM\+Account$'),
             body='{"records": [{"ID": "1"}], "done": false, "nextRecordsUrl": '
-                 '"https://example.com/query/next-records-id"}',
+                 '"https://example.com/query/next-records-id", "totalSize": 2}',
             status=http.OK)
         responses.add(
             responses.GET,
             re.compile(r'^https://.*/query/next-records-id$'),
-            body='{"records": [{"ID": "2"}], "done": true}',
+            body='{"records": [{"ID": "2"}], "done": true, "totalSize": 2}',
             status=http.OK)
         session = requests.Session()
         client = Salesforce(session_id=tests.SESSION_ID,
@@ -695,12 +695,12 @@ class TestSalesforce(unittest.TestCase):
             responses.GET,
             re.compile(r'^https://.*/query/\?q=SELECT\+ID\+FROM\+Account$'),
             body='{"records": [{"ID": "1"}], "done": false, "nextRecordsUrl": '
-                 '"https://example.com/query/next-records-id"}',
+                 '"https://example.com/query/next-records-id", "totalSize": 2}',
             status=http.OK)
         responses.add(
             responses.GET,
             re.compile(r'^https://.*/query/next-records-id$'),
-            body='{"records": [{"ID": "2"}], "done": true}',
+            body='{"records": [{"ID": "2"}], "done": true, "totalSize": 2}',
             status=http.OK)
         session = requests.Session()
         client = Salesforce(session_id=tests.SESSION_ID,
@@ -713,7 +713,7 @@ class TestSalesforce(unittest.TestCase):
             OrderedDict([('records', [
                 OrderedDict([('ID', '1')]),
                 OrderedDict([('ID', '2')])
-            ]), ('done', True)]))
+            ]), ('done', True), ('totalSize', 2)]))
 
     @responses.activate
     def test_query_all_include_deleted(self):
@@ -724,12 +724,12 @@ class TestSalesforce(unittest.TestCase):
             responses.GET,
             re.compile(r'^https://.*/queryAll/\?q=SELECT\+ID\+FROM\+Account$'),
             body='{"records": [{"ID": "1"}], "done": false, "nextRecordsUrl": '
-                 '"https://example.com/queryAll/next-records-id"}',
+                 '"https://example.com/queryAll/next-records-id", "totalSize": 2}',
             status=http.OK)
         responses.add(
             responses.GET,
             re.compile(r'^https://.*/queryAll/next-records-id$'),
-            body='{"records": [{"ID": "2"}], "done": true}',
+            body='{"records": [{"ID": "2"}], "done": true, "totalSize": 2}',
             status=http.OK)
         session = requests.Session()
         client = Salesforce(session_id=tests.SESSION_ID,
@@ -743,7 +743,7 @@ class TestSalesforce(unittest.TestCase):
             OrderedDict([('records', [
                 OrderedDict([('ID', '1')]),
                 OrderedDict([('ID', '2')])
-            ]), ('done', True)]))
+            ]), ('done', True), ('totalSize', 2)]))
 
     @responses.activate
     def test_api_limits(self):


### PR DESCRIPTION
To ensure backward compatibility, we're adding a new method (`query_all_iter`), which is then reused in a new implementation of `query_all`.

Open questions:
- do we need to duplicate docs in README.rst and queries.rst? I just copied it as I saw it in the existing docs.
- ~~what does `query_all` return against a live Salesforce instance? I'll test it tomorrow once I get the chance - I'm not sure if totalSize is a part of the return object or not (the tests don't suggests so, but the docs do)~~

For some context, see #257