### PR TITLE
Resolve "Patch method not allowed"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,15 @@ To change that contact's last name from 'Smith' to 'Jones' and add a first name 
 
     sf.Contact.update('003e0000003GuNXAA0',{'LastName': 'Jones', 'FirstName': 'John'})
 
+To upsert the contact:
+
+.. code-block:: python
+
+    sf.Contact.upsert('externalKeyField__c',{'LastName': 'Jones', 'FirstName': 'John', 'externalKeyField__c':'1234567890'})
+
+Pass in the entire JSON object including your external key field, denoting which field it is. The endpoint for this PATCH call is `.../{sobject_name}/{external_key__c}/external_key__c.fieldValue`. This field will process a single upsert via the REST API. Please see the BULK API instructions further below for processing in batches. This REST approach is recommended for records under 2000. 
+
+
 To delete the contact:
 
 .. code-block:: python

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -714,7 +714,6 @@ class SFType(object):
         because Salesforce requires it not be present in the actual upsert. """
         fullUrl=urljoin(self.base_url, record_id) + '/' + data[external_key]
         del data[external_key]
-
         result = self._call_salesforce(
             method='PATCH', url=fullUrl,
             data=json.dumps(data), headers=headers

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -712,7 +712,7 @@ class SFType(object):
 
         """ Append the external key to the end of our URL. Then remove it
         because Salesforce requires it not be present in the actual upsert. """
-        fullUrl=urljoin(self.base_url, record_id) + '/' + data[external_key]
+        fullUrl=urljoin(self.base_url, external_key) + '/' + data[external_key]
         del data[external_key]
         result = self._call_salesforce(
             method='PATCH', url=fullUrl,

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -691,9 +691,9 @@ class SFType(object):
         )
         return result.json(object_pairs_hook=OrderedDict)
 
-    def upsert(self, record_id, data, raw_response=False, headers=None):
+    def upsert(self, external_key, data, raw_response=False, headers=None):
         """Creates or updates an SObject using a PATCH to
-        `.../{object_name}/{record_id}`.
+        `.../{object_name}/{external_key}/data[external_key]`.
 
         If `raw_response` is false (the default), returns the status code
         returned by Salesforce. Otherwise, return the `requests.Response`
@@ -709,8 +709,14 @@ class SFType(object):
                           directly, instead of the status code.
         * headers -- a dict with additional request headers.
         """
+
+        """ Append the external key to the end of our URL. Then remove it
+        because Salesforce requires it not be present in the actual upsert. """
+        fullUrl=urljoin(self.base_url, record_id) + '/' + data[external_key]
+        del data[external_key]
+
         result = self._call_salesforce(
-            method='PATCH', url=urljoin(self.base_url, record_id),
+            method='PATCH', url=fullUrl,
             data=json.dumps(data), headers=headers
         )
         return self._raw_response(result, raw_response)

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -710,7 +710,7 @@ class SFType(object):
         * headers -- a dict with additional request headers.
         """
         # Append the external key to the end of our URL. Then remove it because Salesforce requires it not be present in the actual upsert. #
-        full_url=urljoin(self.base_url, external_key) + '/' + data[external_key]
+        full_url = urljoin(self.base_url, external_key) + '/' + data[external_key]
         del data[external_key]
         result = self._call_salesforce(
             method='PATCH', url=full_url,

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -709,13 +709,11 @@ class SFType(object):
                           directly, instead of the status code.
         * headers -- a dict with additional request headers.
         """
-
-        """ Append the external key to the end of our URL. Then remove it
-        because Salesforce requires it not be present in the actual upsert. """
-        fullUrl=urljoin(self.base_url, external_key) + '/' + data[external_key]
+        # Append the external key to the end of our URL. Then remove it because Salesforce requires it not be present in the actual upsert. #
+        full_url=urljoin(self.base_url, external_key) + '/' + data[external_key]
         del data[external_key]
         result = self._call_salesforce(
-            method='PATCH', url=fullUrl,
+            method='PATCH', url=full_url,
             data=json.dumps(data), headers=headers
         )
         return self._raw_response(result, raw_response)

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -321,8 +321,8 @@ class TestSFType(unittest.TestCase):
 
         sf_type = _create_sf_type()
         result = sf_type.upsert(
-            record_id='some-case-id',
-            data={'some': 'data'},
+            external_key='some-case-id',
+            data={'some': 'data', 'some-case-id':'externalKey'},
             headers={'Sforce-Auto-Assign': 'FALSE'}
         )
 
@@ -343,8 +343,8 @@ class TestSFType(unittest.TestCase):
 
         sf_type = _create_sf_type()
         result = sf_type.upsert(
-            record_id='some-case-id',
-            data={'some': 'data'}
+            external_key='some-case-id',
+            data={'some': 'data', 'some-case-id':'externalKey'},
         )
 
         self.assertEqual(result, http.OK)

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -314,7 +314,7 @@ class TestSFType(unittest.TestCase):
         """Ensure custom headers are used for upserts"""
         responses.add(
             responses.PATCH,
-            re.compile(r'^https://.*/Case/some-case-id$'),
+            re.compile(r'^https://.*/Case/some-case-id/externalKey$'),
             body='{}',
             status=http.OK
         )
@@ -336,7 +336,7 @@ class TestSFType(unittest.TestCase):
         """Ensure upserts work without custom headers"""
         responses.add(
             responses.PATCH,
-            re.compile(r'^https://.*/Case/some-case-id$'),
+            re.compile(r'^https://.*/Case/some-case-id/externalKey$'),
             body='{}',
             status=http.OK
         )


### PR DESCRIPTION
Salesforce changed how the REST API handles PATCH method at some point. I updated the upsert method to reflect this change. I am not getting that error any more.