### PR TITLE
Send an empty body, not "null" if no data is specified.

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -434,11 +434,14 @@ class Salesforce:
         * data -- A dict of parameters to send in a POST / PUT request
         * kwargs -- Additional kwargs to pass to `requests.request`
         """
+        # If data is None, we should send an empty body, not "null", which is
+        # None in json.
+        json_data = json.dumps(data) if data is not None else None
         result = self._call_salesforce(
             method,
             self.apex_url + action,
             name="apexexcute",
-            data=json.dumps(data), **kwargs
+            data=json_data, **kwargs
         )
         try:
             response_content = result.json()


### PR DESCRIPTION
This tweaks the apexecute method to handle and empty body/data correctly; previously, if the `data` passed into `apexecute` was None, it would be passed through json.dump, production `"null"`.  This data was then passed through the requests library, which happily added a "Content-Length: 4" header which caused Salesforce to (at least in some cases) reject the request.

The solution is simply to check for None, and pass in None explicitly rather than json-ifying it.