### PR TITLE
Add format_soql and format_external_id functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,6 +181,26 @@ While ``query_all`` materializes the whole result into a Python list, ``query_al
     for row in data:
       process(row)
 
+Values used in SOQL queries can be quoted and escaped using ``format_soql``:
+
+.. code-block:: python
+
+    sf.query(format_soql("SELECT Id, Email FROM Contact WHERE LastName = {}", "Jones"))
+    sf.query(format_soql("SELECT Id, Email FROM Contact WHERE LastName = {last_name}", last_name="Jones"))
+    sf.query(format_soql("SELECT Id, Email FROM Contact WHERE LastName IN {names}", names=["Smith", "Jones"]))
+
+To skip quoting and escaping for one value while still using the format string, use ``:literal``:
+
+.. code-block:: python
+
+    sf.query(format_soql("SELECT Id, Email FROM Contact WHERE Income > {:literal}", "USD100"))
+
+To escape a substring used in a LIKE expression while being able to use % around it, use ``:like``:
+
+.. code-block:: python
+
+    sf.query(format_soql("SELECT Id, Email FROM Contact WHERE Name LIKE '{:like}%'", "Jones"))
+
 SOSL queries are done via:
 
 .. code-block:: python
@@ -207,6 +227,12 @@ To insert or update (upsert) a record using an external ID, use:
 .. code-block:: python
 
     sf.Contact.upsert('customExtIdField__c/11999',{'LastName': 'Smith','Email': 'smith@example.com'})
+
+To format an external ID that could contain non-URL-safe characters, use:
+
+.. code-block:: python
+
+    external_id = format_external_id('customExtIdField__c', 'this/that & the other')
 
 To retrieve basic metadata use:
 

--- a/docs/user_guide/misc.rst
+++ b/docs/user_guide/misc.rst
@@ -7,6 +7,12 @@ To insert or update (upsert) a record using an external ID, use:
 
     sf.Contact.upsert('customExtIdField__c/11999',{'LastName': 'Smith','Email': 'smith@example.com'})
 
+To format an external ID that could contain non-URL-safe characters, use:
+
+.. code-block:: python
+
+    external_id = format_external_id('customExtIdField__c', 'this/that & the other')
+
 To retrieve basic metadata use:
 
 .. code-block:: python

--- a/docs/user_guide/queries.rst
+++ b/docs/user_guide/queries.rst
@@ -30,6 +30,26 @@ While ``query_all`` materializes the whole result into a Python list, ``query_al
     for row in data:
       process(row)
 
+Values used in SOQL queries can be quoted and escaped using ``format_soql``:
+
+.. code-block:: python
+
+    sf.query(format_soql("SELECT Id, Email FROM Contact WHERE LastName = {}", "Jones"))
+    sf.query(format_soql("SELECT Id, Email FROM Contact WHERE LastName = {last_name}", last_name="Jones"))
+    sf.query(format_soql("SELECT Id, Email FROM Contact WHERE LastName IN {names}", names=["Smith", "Jones"]))
+
+To skip quoting and escaping for one value while still using the format string, use ``:literal``:
+
+.. code-block:: python
+
+    sf.query(format_soql("SELECT Id, Email FROM Contact WHERE Income > {:literal}", "USD100"))
+
+To escape a substring used in a LIKE expression while being able to use % around it, use ``:like``:
+
+.. code-block:: python
+
+    sf.query(format_soql("SELECT Id, Email FROM Contact WHERE Name LIKE '{:like}%'", "Jones"))
+
 SOSL queries are done via:
 
 .. code-block:: python

--- a/simple_salesforce/__init__.py
+++ b/simple_salesforce/__init__.py
@@ -9,3 +9,4 @@ from .exceptions import (SalesforceAuthenticationFailed, SalesforceError,
                          SalesforceMoreThanOneRecord, SalesforceRefusedRequest,
                          SalesforceResourceNotFound)
 from .login import SalesforceLogin
+from .format import format_soql, format_external_id

--- a/simple_salesforce/format.py
+++ b/simple_salesforce/format.py
@@ -1,0 +1,78 @@
+""" Formatting helpers that perform quoting and escaping """
+
+import urllib.parse
+from datetime import date, datetime, timezone
+from string import Formatter
+
+# https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_quotedstringescapes.htm
+soql_escapes = str.maketrans({
+    '\\': '\\\\',
+    '\'': '\\\'',
+    '"': '\\"',
+    '\n': '\\n',
+    '\r': '\\r',
+    '\t': '\\t',
+    '\b': '\\b',
+    '\f': '\\f',
+})
+
+soql_like_escapes = str.maketrans({
+    '%': '\\%',
+    '_': '\\_',
+})
+
+
+class SoqlFormatter(Formatter):
+    """ Custom formatter to apply quoting or the :literal format spec """
+
+    def format_field(self, value, format_spec):
+        if not format_spec:
+            return quote_soql_value(value)
+        if format_spec == 'literal':
+            # literal: allows circumventing everything while still using
+            # the same format string
+            return value
+        if format_spec == 'like':
+            # like: allows escaping substring used in LIKE expression
+            # does not quote
+            return (str(value).translate(soql_escapes)
+                    .translate(soql_like_escapes))
+        return super().format_field(value, format_spec)
+
+
+def format_soql(query, *args, **kwargs):
+    """ Insert values quoted for SOQL into a format string """
+    return SoqlFormatter().vformat(query, args, kwargs)
+
+
+# pylint: disable=too-many-return-statements
+def quote_soql_value(value):
+    """ Quote/escape either an individual value or a list of values
+    for a SOQL value expression """
+    if isinstance(value, str):
+        return "'" + value.translate(soql_escapes) + "'"
+    if value is True:
+        return 'true'
+    if value is False:
+        return 'false'
+    if value is None:
+        return 'null'
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, (list, set, tuple)):
+        quoted_items = [quote_soql_value(member) for member in value]
+        return '(' + ','.join(quoted_items) + ')'
+    if isinstance(value, datetime):
+        # Salesforce spec requires a datetime literal
+        # that is not naive and without MS
+        value = value.replace(microsecond=0)
+        value = value.astimezone(tz=timezone.utc)
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    raise ValueError('unquotable value type')
+
+
+def format_external_id(field, value):
+    """ Create an external ID string for use with get() or upsert() """
+    return field + '/' + urllib.parse.quote(value, safe='')

--- a/simple_salesforce/tests/test_format.py
+++ b/simple_salesforce/tests/test_format.py
@@ -1,0 +1,118 @@
+""" Tests for format.py """
+
+import unittest
+from datetime import datetime, date, timezone
+from simple_salesforce import format_soql, format_external_id
+
+
+class TestFormatSoql(unittest.TestCase):
+    """ Test quoting/escaping of SOQL strings """
+
+    def test_plain_string(self):
+        """ Case where there is no quoting """
+        query = "select foo from bar where x = 'y'"
+        quoted = format_soql(query)
+        self.assertEqual(quoted, query)
+
+    def test_no_escape_needed(self):
+        """ Quotes but doesn't escape simple values """
+        query = "select foo from bar where x = {} and y = {named}"
+        expected = "select foo from bar where x = 'value1' and y = 'value2'"
+        quoted = format_soql(query, 'value1', named='value2')
+        self.assertEqual(quoted, expected)
+
+    def test_escaped_chars(self):
+        """ Quotes and escape special chars """
+        query = "select foo from bar where x = {} and y = {named}"
+        expected = (
+            "select foo from bar where"
+            " x = 'val\\'ue1\\n' and y = 'val\\'ue2\\n'"
+        )
+        quoted = format_soql(query, 'val\'ue1\n', named='val\'ue2\n')
+        self.assertEqual(quoted, expected)
+
+    def test_lists(self):
+        """ Conversion of lists to parentheses groups """
+        query = "select foo from bar where x in {} and y in {named}"
+        expected = (
+            "select foo from bar where"
+            " x in ('value1','val\\'ue1\\n')"
+            " and y in ('value2','val\\'ue2\\n')"
+        )
+        quoted = format_soql(
+            query,
+            ['value1', 'val\'ue1\n'],
+            named=['value2', 'val\'ue2\n']
+        )
+        self.assertEqual(quoted, expected)
+
+    def test_number(self):
+        """ Numbers are inserted without quoting """
+        query = "select foo from bar where x = {} and y = {named}"
+        expected = "select foo from bar where x = 1 and y = 2.37"
+        quoted = format_soql(query, 1, named=2.37)
+        self.assertEqual(quoted, expected)
+
+    def test_booleans(self):
+        """ Boolean literals are inserted """
+        query = "select foo from bar where truth = {} and lies = {}"
+        expected = "select foo from bar where truth = false and lies = true"
+        quoted = format_soql(query, False, True)
+        self.assertEqual(quoted, expected)
+
+    def test_null(self):
+        """ Null literals are inserted """
+        query = "select foo from bar where name != {}"
+        expected = "select foo from bar where name != null"
+        quoted = format_soql(query, None)
+        self.assertEqual(quoted, expected)
+
+    def test_date(self):
+        """ Date literals are inserted """
+        query = "select foo from bar where date = {}"
+        expected = "select foo from bar where date = 1987-02-01"
+        quoted = format_soql(query, date(1987, 2, 1))
+        self.assertEqual(quoted, expected)
+
+    def test_datetime(self):
+        """ Datetime literals are inserted """
+        query = "select foo from bar where date = {}"
+        expected = "select foo from bar where date = 1987-02-01T01:02:03+00:00"
+        quoted = format_soql(
+            query,
+            datetime(1987, 2, 1, 1, 2, 3, tzinfo=timezone.utc)
+        )
+        self.assertEqual(quoted, expected)
+
+    def test_literal(self):
+        """ :literal format spec """
+        query = "select foo from bar where income > {amt:literal}"
+        expected = "select foo from bar where income > USD100"
+        quoted = format_soql(query, amt='USD100')
+        self.assertEqual(quoted, expected)
+
+    def test_like(self):
+        """ :like format spec """
+        query = "select foo from bar where name like '%{:like}%'"
+        expected = "select foo from bar where name like '%foo\\'\\%bar\\_%'"
+        quoted = format_soql(query, 'foo\'%bar_')
+        self.assertEqual(quoted, expected)
+
+    def test_invalid(self):
+        """ Unexpected value type """
+        with self.assertRaises(ValueError):
+            format_soql('select foo from bar where x = {}', {'x': 'y'})
+
+
+class TestFormatExternalId(unittest.TestCase):
+    """ Test formatting external IDs """
+
+    def test_plain_string(self):
+        """ Case where no escaping is needed """
+        ext_id = format_external_id('name', 'something')
+        self.assertEqual(ext_id, 'name/something')
+
+    def test_quoted(self):
+        """ Value requring some quoting """
+        ext_id = format_external_id('name', 'some/other\'type value')
+        self.assertEqual(ext_id, 'name/some%2Fother%27type%20value')


### PR DESCRIPTION
Resolves https://github.com/simple-salesforce/simple-salesforce/issues/389. This adds a couple of simple utility functions to perform needed quoting & escaping in order to prevent errors or injections. Tests & docs included.

While this started out with string quoting, which I implemented in a work project and have been running, I quickly realized the need to include other types, as well as the need for 2 additional cases: `literal` exists to prevent users from having to use nested format strings to add things like dynamic object names in other ways, and `like` exists because, given an entire right side value for a like expression, it's not possible to tell which `_` and `%` characters are intended to be wildcards and which are part of a dynamic input.