### PR TITLE
Add parameter to allow JWT expiry in local timezone

### DIFF
--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -8,7 +8,7 @@ DEFAULT_CLIENT_ID_PREFIX = 'RestForce'
 
 import time
 import warnings
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from html import escape
 from json.decoder import JSONDecodeError
 
@@ -154,7 +154,7 @@ def SalesforceLogin(
             consumer_key is not None and \
             privatekey_file is not None:
         header = {'alg': 'RS256'}
-        expiration = datetime.utcnow() + timedelta(minutes=3)
+        expiration = datetime.now(timezone.utc).astimezone() + timedelta(minutes=3)
         payload = {
             'iss': consumer_key,
             'sub': username,

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -33,7 +33,7 @@ def SalesforceLogin(
     domain=None,
     consumer_key=None,
     privatekey_file=None,
-    set_exp_to_local = False
+    set_exp_to_local=False,
 ):
     """Return a tuple of `(session_id, sf_instance)` where `session_id` is the
     session ID to use for authentication to Salesforce and `sf_instance` is

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -155,9 +155,7 @@ def SalesforceLogin(
             consumer_key is not None and \
             privatekey_file is not None:
         header = {'alg': 'RS256'}
-        dt = datetime.utcnow()
-        if set_exp_to_local:
-            dt = datetime.now(timezone.utc).astimezone()
+        dt = datetime.now(timezone.utc).astimezone() if set_exp_to_local else datetime.utcnow()
         expiration = dt + timedelta(minutes=3)
         payload = {
             'iss': consumer_key,

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -33,6 +33,7 @@ def SalesforceLogin(
     domain=None,
     consumer_key=None,
     privatekey_file=None,
+    set_exp_to_local = False
 ):
     """Return a tuple of `(session_id, sf_instance)` where `session_id` is the
     session ID to use for authentication to Salesforce and `sf_instance` is
@@ -154,7 +155,10 @@ def SalesforceLogin(
             consumer_key is not None and \
             privatekey_file is not None:
         header = {'alg': 'RS256'}
-        expiration = datetime.now(timezone.utc).astimezone() + timedelta(minutes=3)
+        dt = datetime.utcnow()
+        if set_exp_to_local:
+            dt = datetime.now(timezone.utc).astimezone()
+        expiration = dt + timedelta(minutes=3)
         payload = {
             'iss': consumer_key,
             'sub': username,


### PR DESCRIPTION
This allows the users to utilize the JWT method in local timezone instead of UTC