### PR TITLE
Explicitly encode XML as UTF-8.

### DIFF
--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -103,7 +103,7 @@ def SalesforceLogin(
             </env:Body>
         </env:Envelope>""".format(
             username=username, password=password, token=security_token,
-            client_id=client_id)
+            client_id=client_id).encode(encoding='UTF-8',errors='strict')
 
     # Check if IP Filtering is used in conjunction with organizationId
     elif organizationId is not None:
@@ -129,7 +129,7 @@ def SalesforceLogin(
             </soapenv:Body>
         </soapenv:Envelope>""".format(
             username=username, password=password, organizationId=organizationId,
-            client_id=client_id)
+            client_id=client_id).encode(encoding='UTF-8',errors='strict')
     elif username is not None and password is not None:
         # IP Filtering for non self-service users
         login_soap_request_body = """<?xml version="1.0" encoding="utf-8" ?>
@@ -149,7 +149,7 @@ def SalesforceLogin(
                 </urn:login>
             </soapenv:Body>
         </soapenv:Envelope>""".format(
-            username=username, password=password, client_id=client_id)
+            username=username, password=password, client_id=client_id).encode(encoding='UTF-8',errors='strict')
     elif username is not None and \
             consumer_key is not None and \
             privatekey_file is not None:


### PR DESCRIPTION
I had the problem my password contained multi-byte UTF-8 characters. Unfortunately if you pass a string as the request body to a requests POST, it seems to (wrongly) encode this as Latin-1 encoding (see also: https://github.com/psf/requests/issues/4503). As this is unexpected and XML declaration states it should be UTF-8, it should also be explicitly encoded as UTF-8.