### PR TITLE
Update api.py. Fix typo name parameter value

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -478,7 +478,7 @@ class Salesforce:
         result = self._call_salesforce(
             method,
             self.apex_url + action,
-            name="apexexcute",
+            name="apexecute",
             data=json_data, **kwargs
             )
         try:


### PR DESCRIPTION
Name parameter had value = apexexcute but method has name = apexecute