### PR TITLE
prevents silent failure of bulk API by preventing NaN in payload.

### DIFF
--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -102,7 +102,13 @@ class SFBulkType:
 
         result = call_salesforce(url=url, method='POST', session=self.session,
                                  headers=self.headers,
-                                 data=json.dumps(payload))
+                                 data=json.
+                                 
+                                 
+                                 
+                                 
+                                 
+                                 (payload, allow_nan=False))
         return result.json(object_pairs_hook=OrderedDict)
 
     def _close_job(self, job_id):
@@ -115,7 +121,7 @@ class SFBulkType:
 
         result = call_salesforce(url=url, method='POST', session=self.session,
                                  headers=self.headers,
-                                 data=json.dumps(payload))
+                                 data=json.dumps(payload, allow_nan=False))
         return result.json(object_pairs_hook=OrderedDict)
 
     def _get_job(self, job_id):
@@ -135,7 +141,7 @@ class SFBulkType:
         url = "{}{}{}{}".format(self.bulk_url, 'job/', job_id, '/batch')
 
         if operation not in ('query', 'queryAll'):
-            data = json.dumps(data)
+            data = json.dumps(data, allow_nan=False)
 
         result = call_salesforce(url=url, method='POST', session=self.session,
                                  headers=self.headers, data=data)

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -102,13 +102,7 @@ class SFBulkType:
 
         result = call_salesforce(url=url, method='POST', session=self.session,
                                  headers=self.headers,
-                                 data=json.
-                                 
-                                 
-                                 
-                                 
-                                 
-                                 (payload, allow_nan=False))
+                                 data=json.dumps(payload, allow_nan=False))
         return result.json(object_pairs_hook=OrderedDict)
 
     def _close_job(self, job_id):


### PR DESCRIPTION
calling `json.dumps` with `allow_nan=True` (which is the default) results in a silently failing batch.  This patch fixes https://github.com/simple-salesforce/simple-salesforce/issues/442 by calling `json.dumps` with `allow_nan=False`.  This will cause code with `NaN` in it to fail fast, rather than silently if involved in a large-sized batch.