### PR TITLE
Support signing JWT without requiring a file to read the key from

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -49,6 +49,7 @@ class Salesforce:
             domain=None,
             consumer_key=None,
             privatekey_file=None,
+            privatekey=None,
             ):
         """Initialize the instance with the given parameters.
 
@@ -67,8 +68,13 @@ class Salesforce:
         OAuth 2.0 JWT Bearer Token Authentication:
 
         * consumer_key -- the consumer key generated for the user
+
+        Then either
         * privatekey_file -- the path to the private key file used
                              for signing the JWT token
+        OR
+        * privatekey -- the private key to use
+                         for signing the JWT token
 
         Direct Session and Instance Access:
 
@@ -155,7 +161,7 @@ class Salesforce:
                 domain=self.domain)
 
         elif all(arg is not None for arg in (
-                username, consumer_key, privatekey_file)):
+                username, consumer_key, privatekey_file or privatekey)):
             self.auth_type = "jwt-bearer"
 
             # Pass along the username/password to our login helper
@@ -164,6 +170,7 @@ class Salesforce:
                 username=username,
                 consumer_key=consumer_key,
                 privatekey_file=privatekey_file,
+                privatekey=privatekey,
                 proxies=self.proxies,
                 domain=self.domain)
 

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -33,6 +33,7 @@ def SalesforceLogin(
     domain=None,
     consumer_key=None,
     privatekey_file=None,
+    privatekey=None,
 ):
     """Return a tuple of `(session_id, sf_instance)` where `session_id` is the
     session ID to use for authentication to Salesforce and `sf_instance` is
@@ -58,7 +59,9 @@ def SalesforceLogin(
                 'login'.
     * consumer_key -- the consumer key generated for the user
     * privatekey_file -- the path to the private key file used
-                         for signing the JWT token
+                         for signing the JWT token.
+    * privatekey -- the private key to use
+                         for signing the JWT token.
     """
 
     if domain is None:
@@ -152,7 +155,7 @@ def SalesforceLogin(
             username=username, password=password, client_id=client_id)
     elif username is not None and \
             consumer_key is not None and \
-            privatekey_file is not None:
+            (privatekey_file is not None or privatekey is not None):
         header = {'alg': 'RS256'}
         expiration = datetime.utcnow() + timedelta(minutes=3)
         payload = {
@@ -164,8 +167,13 @@ def SalesforceLogin(
                     expiration.microsecond / 1e6
             )
         }
-        with open(privatekey_file, 'rb') as key:
-            assertion = jwt.encode(header, payload, key.read())
+        if privatekey_file is not None:
+            with open(privatekey_file, 'rb') as key_file:
+                key = key_file.read()
+        else:
+            key = privatekey
+
+        assertion = jwt.encode(header, payload, key)
 
         login_token_request_data = {
             'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer',

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -126,12 +126,42 @@ class TestSalesforceLogin(unittest.TestCase):
         self.assertTrue(self.mockrequest.post.called)
 
     @responses.activate
-    def test_token_login_success(self):
-        """Test a successful JWT Token login"""
+    def test_token_login_success_with_key_file(self):
+        """Test a successful JWT Token login with a key file"""
         pkey_file = os.path.join(os.path.dirname(__file__), 'sample-key.pem')
         login_args = {
             'consumer_key': '12345.abcde',
             'privatekey_file': pkey_file
+        }
+        self._test_login_success(
+            re.compile(r'^https://login.salesforce.com/.*$'), login_args,
+            response_body=tests.TOKEN_LOGIN_RESPONSE_SUCCESS)
+
+    @responses.activate
+    def test_token_login_success_with_key(self):
+        """Test a successful JWT Token login with a key from a string"""
+        pkey_file = os.path.join(os.path.dirname(__file__), 'sample-key.pem')
+        with open(pkey_file, 'rb') as key_file:
+            key = key_file.read().decode("utf-8")
+
+        login_args = {
+            'consumer_key': '12345.abcde',
+            'privatekey': key
+        }
+        self._test_login_success(
+            re.compile(r'^https://login.salesforce.com/.*$'), login_args,
+            response_body=tests.TOKEN_LOGIN_RESPONSE_SUCCESS)
+
+    @responses.activate
+    def test_token_login_success_with_key_bytes(self):
+        """Test a successful JWT Token login with key bytes"""
+        pkey_file = os.path.join(os.path.dirname(__file__), 'sample-key.pem')
+        with open(pkey_file, 'rb') as key:
+            key_bytes = key.read()
+
+        login_args = {
+            'consumer_key': '12345.abcde',
+            'privatekey': key_bytes
         }
         self._test_login_success(
             re.compile(r'^https://login.salesforce.com/.*$'), login_args,


### PR DESCRIPTION
Adds the ability to pass a private key as `bytes` or `str` when using the JWT auth flow. This makes it so the key does not need to reside on a disk accessible to the code, which is especially useful for serverless deployments.

- `privatekey` parameter added to `Salesforce` and `SalesforceLogin`

`privatekey_file` takes precedence over `privatekey` if both are passed. 