### PR TITLE
Fix set password to handel empty response on success

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -279,17 +279,17 @@ class Salesforce:
 
         result = self._call_salesforce('POST', url, data=json.dumps(params))
 
+        if result.status_code == 204:
+            return None
+
         # salesforce return 204 No Content when the request is successful
-        if result.status_code != 200 and result.status_code != 204:
+        if result.status_code != 200:
             raise SalesforceGeneralError(url,
                                          result.status_code,
                                          'User',
                                          result.content)
-        json_result = result.json(object_pairs_hook=OrderedDict)
-        if len(json_result) == 0:
-            return None
+        return result.json(object_pairs_hook=OrderedDict)
 
-        return json_result
 
     # Generic Rest Function
     def restful(self, path, params=None, method='GET', **kwargs):


### PR DESCRIPTION
Fixes https://github.com/simple-salesforce/simple-salesforce/issues/145

The REST API of salesforce returns a 204 status code without any data on successful password change. This is a minimal change from the previous implementation. However, it looks like the json parsing for the status code 200 can also be removed. 

https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_user_password.htm


