### PR TITLE
Fixing deploy packages: RunSpecifiedTests

### DIFF
--- a/simple_salesforce/metadata.py
+++ b/simple_salesforce/metadata.py
@@ -77,7 +77,7 @@ class SfdcMetadataApi:
 
         tests_tag = ''
         if tests and \
-                str(tests).lower() == 'runspecifiedtests':
+                str(testLevel).lower() == 'runspecifiedtests':
             for test in tests:
                 tests_tag += '<met:runTests>%s</met:runTests>\n' % test
             attributes['tests'] = tests_tag


### PR DESCRIPTION
the code compared the wrong variable:
`tests` is a list of test names, `testLevel` is the one we need. 