### PR TITLE
Add parse_float function to allow parsing floats to decimal.Decimal

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -26,12 +26,12 @@ PerAppUsage = namedtuple('PerAppUsage', 'used total name')
 
 # pylint: disable=too-many-instance-attributes
 class Salesforce:
-    _parse_float = None
     """Salesforce Instance
 
     An instance of Salesforce is a handy way to wrap a Salesforce session
     for easy use of the Salesforce REST API.
     """
+    _parse_float = None
 
     # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
     def __init__(
@@ -97,7 +97,8 @@ class Salesforce:
         * session -- Custom requests session, created in calling code. This
                      enables the use of requests Session features not otherwise
                      exposed by simple_salesforce.
-
+        * parse_float -- Function to parse float values with. Is passed along to
+                         https://docs.python.org/3/library/json.html#json.load
         """
 
         if domain is None:
@@ -638,7 +639,9 @@ class Salesforce:
         return results
 
     def parse_result_to_json(self, result):
-        return result.json(object_pairs_hook=OrderedDict, parse_float=self._parse_float)
+        """"Parse json from a Response object"""
+        return result.json(object_pairs_hook=OrderedDict,
+                           parse_float=self._parse_float)
 
 
 class SFType:
@@ -669,6 +672,8 @@ class SFType:
         * session -- Custom requests session, created in calling code. This
                      enables the use of requests Session features not otherwise
                      exposed by simple_salesforce.
+        * parse_float -- Function to parse float values with. Is passed along to
+                         https://docs.python.org/3/library/json.html#json.load
         """
         self.session_id = session_id
         self.name = object_name
@@ -936,4 +941,6 @@ class SFType:
         return response
 
     def parse_result_to_json(self, result):
-        return result.json(object_pairs_hook=OrderedDict, parse_float=self._parse_float)
+        """"Parse json from a Response object"""
+        return result.json(object_pairs_hook=OrderedDict,
+                           parse_float=self._parse_float)

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -50,6 +50,7 @@ class Salesforce:
             consumer_key=None,
             privatekey_file=None,
             privatekey=None,
+            parse_float=None,
             ):
 
         """Initialize the instance with the given parameters.
@@ -203,6 +204,8 @@ class Salesforce:
         self.tooling_url = '{base_url}tooling/'.format(base_url=self.base_url)
 
         self.api_usage = {}
+
+        self.parse_float = parse_float
 
     def describe(self, **kwargs):
         """Describes all available objects
@@ -378,7 +381,7 @@ class Salesforce:
         result = self._call_salesforce('GET', url, name='query',
                                        params=params, **kwargs)
 
-        return result.json(object_pairs_hook=OrderedDict)
+        return result.json(object_pairs_hook=OrderedDict, parse_float=self.parse_float)
 
     def query_more(
             self, next_records_identifier, identifier_is_url=False,
@@ -412,7 +415,7 @@ class Salesforce:
                              next_record_id=next_records_identifier)
         result = self._call_salesforce('GET', url, name='query_more', **kwargs)
 
-        return result.json(object_pairs_hook=OrderedDict)
+        return result.json(object_pairs_hook=OrderedDict, parse_float=self.parse_float)
 
     def query_all_iter(self, query, include_deleted=False, **kwargs):
         """This is a lazy alternative to `query_all` - it does not construct

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -452,6 +452,7 @@ class TestSFType(unittest.TestCase):
 
         sf_type = _create_sf_type()
         result = sf_type.get(record_id='444')
+        self.assertIsInstance(result['currency'], float)
         self.assertEqual(result, {"currency": 42.0})
 
     @responses.activate
@@ -472,6 +473,7 @@ class TestSFType(unittest.TestCase):
             parse_float=decimal.Decimal
         )
         result = sf_type.get(record_id='444')
+        self.assertIsInstance(result['currency'], decimal.Decimal)
         self.assertEqual(result, {"currency": decimal.Decimal("42.0")})
 
 

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -3,6 +3,7 @@
 import http.client as http
 import re
 import unittest
+import decimal
 from collections import OrderedDict
 from datetime import datetime
 from unittest.mock import patch
@@ -1064,10 +1065,11 @@ class TestSalesforce(unittest.TestCase):
     @responses.activate
     def test_query_parse_float_to_decimal(self):
         """Test querying generates float as Decimal values"""
-        import decimal
         responses.add(
             responses.GET,
-            re.compile(r'^https://.*/query/\?q=SELECT\+currency\+FROM\+Account$'),
+            re.compile(
+                r'^https://.*/query/\?q=SELECT\+currency\+FROM\+Account$'
+            ),
             body='{"currency": 1.0}',
             status=http.OK,
         )
@@ -1089,7 +1091,6 @@ class TestSalesforce(unittest.TestCase):
     @responses.activate
     def test_query_more_parse_float_to_decimal(self):
         """Test querying generates float as Decimal values"""
-        import decimal
         responses.add(
             responses.GET,
             re.compile(r'^https://.*/query/next-records-id$'),

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -464,10 +464,14 @@ class TestSFType(unittest.TestCase):
             status=http.OK
         )
 
-        sf_type = _create_sf_type()
-        sf_type._parse_float = decimal.Decimal
+        sf_type = SFType(
+            object_name='Case',
+            session_id='5',
+            sf_instance='my.salesforce.com',
+            session=requests.Session(),
+            parse_float=decimal.Decimal
+        )
         result = sf_type.get(record_id='444')
-
         self.assertEqual(result, {"currency": decimal.Decimal("42.0")})
 
 

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -440,6 +440,36 @@ class TestSFType(unittest.TestCase):
 
         self.assertEqual(result, {})
 
+    @responses.activate
+    def test_get_parse_float_as_float(self):
+        """Ensure custom headers are used for get requests"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*/Case/444$'),
+            body='{"currency": 42.0}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        result = sf_type.get(record_id='444')
+        self.assertEqual(result, {"currency": 42.0})
+
+    @responses.activate
+    def test_get_parse_float_as_decimal(self):
+        """Ensure custom headers are used for get requests"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*/Case/444$'),
+            body='{"currency": 42.0}',
+            status=http.OK
+        )
+
+        sf_type = _create_sf_type()
+        sf_type._parse_float = decimal.Decimal
+        result = sf_type.get(record_id='444')
+
+        self.assertEqual(result, {"currency": decimal.Decimal("42.0")})
+
 
 class TestSalesforce(unittest.TestCase):
     """Tests for the Salesforce instance"""


### PR DESCRIPTION
Ran into #135, where currency values were parsed incorrectly into floats. 

This PR adds an argument to `Salesforce` and `SFType` named `parse_float`. `parse_float` is passed to [json.loads](https://docs.python.org/3/library/json.html#json.loads) via [Response.json](https://github.com/psf/requests/blob/master/requests/models.py#L881).

I've added tests for both `Salesforce` and `SFType` to parse both floats and decimals.

Usage:
```python
>>> import decimal
>>> sf = Salesforce(..., parse_float=decimal.Decimal)
```