### PR TITLE
Support non-standard https port number

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -143,6 +143,8 @@ class Salesforce:
             # interface for example) extract the hostname (which we rely on)
             if instance_url is not None:
                 self.sf_instance = urlparse(instance_url).hostname
+                port = urlparse(instance_url).port
+                if port != 443: self.sf_instance += ':' + str(port)
             else:
                 self.sf_instance = instance
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -144,7 +144,7 @@ class Salesforce:
             if instance_url is not None:
                 self.sf_instance = urlparse(instance_url).hostname
                 port = urlparse(instance_url).port
-                if port != None and port != 443: self.sf_instance += ':' + str(port)
+                if port not in (None, 443): self.sf_instance += ':' + str(port)
             else:
                 self.sf_instance = instance
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -144,7 +144,7 @@ class Salesforce:
             if instance_url is not None:
                 self.sf_instance = urlparse(instance_url).hostname
                 port = urlparse(instance_url).port
-                if port != 443: self.sf_instance += ':' + str(port)
+                if port != None and port != 443: self.sf_instance += ':' + str(port)
             else:
                 self.sf_instance = instance
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -144,7 +144,8 @@ class Salesforce:
             if instance_url is not None:
                 self.sf_instance = urlparse(instance_url).hostname
                 port = urlparse(instance_url).port
-                if port not in (None, 443): self.sf_instance += ':' + str(port)
+                if port not in (None, 443):
+                    self.sf_instance += ':' + str(port)
             else:
                 self.sf_instance = instance
 


### PR DESCRIPTION
This is a self-explanatory two-line change for supporting non-standard https port number (other than 443) used by the instance URL. I would like you to merge into the master branch. Thanks.