### PR TITLE
Add auto-completion for SObject names

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -207,6 +207,12 @@ class Salesforce:
 
         self.api_usage = {}
 
+        try:
+            self._sobject_names = [x['name'] for x
+                                   in self.describe()['sobjects']]
+        except: # pylint: disable=bare-except
+            self._sobject_names = []
+
     def describe(self, **kwargs):
         """Describes all available objects
 
@@ -233,6 +239,10 @@ class Salesforce:
                 0].get(
                 'IsSandbox')
         return is_sandbox
+
+    # Include SObject names in dir for auto-completion
+    def __dir__(self):
+        return super().__dir__() + self._sobject_names
 
     # SObject Handler
     def __getattr__(self, name):


### PR DESCRIPTION
Salesforce objects retrieve SObject names during initialization and append them to the normal elements returned by __dir__, allowing for auto-complete of SObject names found in the Salesforce instance. (Sadly, not all IDEs support auto-completion using __dir__.)