### PR TITLE
Strip leading v from api_version

### DIFF
--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -65,8 +65,10 @@ def SalesforceLogin(
 
     if domain is None:
         domain = 'login'
-
-    soap_url = 'https://{domain}.salesforce.com/services/Soap/u/{sf_version.lstrip("v")}'
+    
+    sf_version = sf_version.lstrip("v")
+    
+    soap_url = 'https://{domain}.salesforce.com/services/Soap/u/{sf_version}'
 
     if client_id:
         client_id = "{prefix}/{app_name}".format(

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -66,7 +66,7 @@ def SalesforceLogin(
     if domain is None:
         domain = 'login'
 
-    soap_url = 'https://{domain}.salesforce.com/services/Soap/u/{sf_version}'
+    soap_url = 'https://{domain}.salesforce.com/services/Soap/u/{sf_version.lstrip("v")}'
 
     if client_id:
         client_id = "{prefix}/{app_name}".format(

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -66,7 +66,12 @@ def SalesforceLogin(
     if domain is None:
         domain = 'login'
     
-    sf_version = sf_version.lstrip("v")
+    if sf_version.startswith("v"):
+        error_msg = (
+            "Invalid sf_version specified ({version}). Version should not "
+            "contain a leading 'v'".format(version=sf_version)
+        )
+        raise ValueError(error_msg)
     
     soap_url = 'https://{domain}.salesforce.com/services/Soap/u/{sf_version}'
 


### PR DESCRIPTION
This is related to #506, and  is really more of a fix for a salesforce bug than a library bug.

The behavior that I've noticed is that specifying a version in the SOAP url  with a leading 'v', such as 'v51.0', salesforce returns a server_url with version '7.0' which is soon to be retired. I'd expect the specifying an invalid version in the login url to result in an error from salesforce rather than it being silently thrown out and replaced with a soon-to-be-retired version, which is really surprising behavior from a user perspective. 

This PR's approach is one option for working around that behavior. This is one approach that doesn't change the library interface at all, If you'd prefer this to just raise a ValueError if the user specifies an invalid api_version -- which is arguably more correct -- I can update this PR to use that approach as well. 
