### PR TITLE
Issue 523: Add kwargs to query_more call in query_all_iter

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -444,7 +444,8 @@ class Salesforce:
             # fetch next batch if we're not done else break out of loop
             if not result['done']:
                 result = self.query_more(result['nextRecordsUrl'],
-                                         identifier_is_url=True)
+                                         identifier_is_url=True,
+                                         **kwargs)
             else:
                 return
 


### PR DESCRIPTION
To address https://github.com/simple-salesforce/simple-salesforce/issues/523

This has been tested by overriding the method locally, and has run successfully, allowing us to capture timeout errors and address appropriately.