### PR TITLE
Added the ability to stream results from the bulk API.  

### DIFF
--- a/docs/user_guide/queries.rst
+++ b/docs/user_guide/queries.rst
@@ -67,3 +67,23 @@ Search and Quick Search return ``None`` if there are no records, otherwise they 
 More details about syntax is available on the `Salesforce Query Language Documentation Developer Website`_
 
 .. _Salesforce Query Language Documentation Developer Website: http://www.salesforce.com/us/developer/docs/soql_sosl/index.htm
+
+Query results from the bulk API can be streamed to reduce memory usage.  This is useful when dealing with extremely large result sets.
+
+.. code-block:: python
+    from simple_salesforce.bulk import SFBulkStreamMethod
+
+    results = sf.bulk.Contact.query("SELECT Id,AccountId,Email,FirstName,LastName FROM Contact LIMIT 1000000",
+                                    stream_results=SFBulkStreamMethod.STREAM_AS_JSON)
+    for record in results:
+        process(record)
+
+Parsing streamed results from the bulk API can be extremely slow, since the json-stream library is not very fast.  For high throughput use cases, the STREAM_AS_TEXT flag can be passed.
+
+.. code-block:: python
+    from simple_salesforce.bulk import SFBulkStreamMethod
+
+    results = sf.bulk.Contact.query("SELECT Id,AccountId,Email,FirstName,LastName FROM Contact LIMIT 1000000",
+                                    stream_results=SFBulkStreamMethod.STREAM_AS_TEXT)
+    for line in results:
+        process(line)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     install_requires=[
         'requests>=2.22.0',
         'authlib',
-        'zeep'
+        'zeep',
+        'json-stream>=1.3.0'
     ],
     tests_require=[
         'nose>=1.3.0',

--- a/simple_salesforce/__version__.py
+++ b/simple_salesforce/__version__.py
@@ -5,7 +5,7 @@ This file shamelessly taken from the requests library"""
 __title__ = 'simple-salesforce'
 __description__ = 'A basic Salesforce.com REST API client.'
 __url__ = 'https://github.com/simple-salesforce/simple-salesforce'
-__version__ = '1.11.5'
+__version__ = '1.11.6'
 __author__ = 'Nick Catalano'
 __author_email__ = 'nickcatal@gmail.com'
 __license__ = 'Apache 2.0'


### PR DESCRIPTION
I have been using simple-salesforce to pull information from our very large SFDC instance.  I discovered that the bulk API implementation can allocate large amounts of memory when pulling extremely large result sets.

This commit provides the ability to stream results from the bulk api, which keeps the memory footprint low.  

I have provided two mechanisms for streaming from the bulk API, one is streamed JSON, which uses the json-stream library, and the other is streamed plain text.  