### PR TITLE
Replace Authlib with PyJWT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         },
 install_requires = [
                        'requests>=2.22.0',
-                       'authlib',
+                       'pyjwt',
                        'zeep'
                        ],
                    tests_require = [

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -12,7 +12,7 @@ from html import escape
 from json.decoder import JSONDecodeError
 
 import requests
-from authlib.jose import jwt
+import jwt
 
 from .api import DEFAULT_API_VERSION
 from .exceptions import SalesforceAuthenticationFailed
@@ -155,7 +155,6 @@ def SalesforceLogin(
     elif username is not None and \
             consumer_key is not None and \
             (privatekey_file is not None or privatekey is not None):
-        header = {'alg': 'RS256'}
         expiration = datetime.now(timezone.utc) + timedelta(minutes=3)
         payload = {
             'iss': consumer_key,
@@ -170,8 +169,7 @@ def SalesforceLogin(
                 key = key_file.read()
         else:
             key = privatekey
-
-        assertion = jwt.encode(header, payload, key)
+        assertion = jwt.encode(payload, key, algorithm='RS256')
 
         login_token_request_data = {
             'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer',


### PR DESCRIPTION
Authlib is a huge library, mostly intended for implementing OAuth2 and OIDC **providers**, as stated in [the official website](https://authlib.org/):
> The ultimate Python library in building OAuth and OpenID Connect servers.

simple-salesforce is using it just for JWT encoding [here](https://github.com/simple-salesforce/simple-salesforce/blob/master/simple_salesforce/login.py#L174), which is a bit of an overkill.

This PR replaces Authlib with the much smaller and simpler PyJWT library for encoding JWTs.