### PR TITLE
Implement wait param in non-query bulk operations

### DIFF
--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -223,9 +223,9 @@ class SFBulkType:
                     [data[i * batch_size:(i + 1) * batch_size]
                      for i in range((len(data) // batch_size + 1))] if i]
 
-                multi_thread_worker = partial(
-                    self.worker, operation=operation, wait=wait
-                )
+                multi_thread_worker = partial(self.worker,
+                                              operation=operation,
+                                              wait=wait)
                 list_of_results = pool.map(multi_thread_worker, batches)
 
                 results = [x for sublist in list_of_results for i in

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -223,7 +223,9 @@ class SFBulkType:
                     [data[i * batch_size:(i + 1) * batch_size]
                      for i in range((len(data) // batch_size + 1))] if i]
 
-                multi_thread_worker = partial(self.worker, operation=operation)
+                multi_thread_worker = partial(
+                    self.worker, operation=operation, wait=wait
+                )
                 list_of_results = pool.map(multi_thread_worker, batches)
 
                 results = [x for sublist in list_of_results for i in


### PR DESCRIPTION
Add the wait parameter to workers spawned from _bulk_operation for non-query calls (it already exists for query calls). This should have no impact in 99% of cases, as the wait parameter is not exposed on higher-level calls, but allows for manual control over response times for the highly-motivated.