### PR TITLE
create dynamic sized batches to respect bulk api limits

### DIFF
--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -200,21 +200,42 @@ class SFBulkType:
         bulk v1 api has following limits
         number of records <= 10000
         AND
-        max file size <= 10MB
+        file_size_limit <= 10MB
+        AND
+        number_of_character_limit <= 10000000
+
+        testing for number of characters ensures that file size limit is
+        respected.
+
+        this is due to json serialization of multibyte characters.
 
         TODO: In future when simple-salesforce supports bulk api V2
         we should detect api version and set max file size accordingly. V2
         increases file size limit to 150MB
+
+        TODO: support for the following limits have not been added since these
+        are record / field level limits and not chunk level limits:
+        * Maximum number of fields in a record: 5,000
+        * Maximum number of characters in a record: 400,000
+        * Maximum number of characters in a field: 131,072
         """
         file_limit = 1024 * 1024 * 10 # 10MB in bytes
         rec_limit = 10000
+        char_limit = 10000000
 
         batches = []
         last_break = 0
-        nrecs, outsize = 0, 0
+        nrecs, outsize, outchars = 0, 0, 0
         for i, rec in enumerate(data):
-            recsize = len(json.dumps(rec, default=str).encode()) + 2
-            if (outsize + recsize + 2) > file_limit or nrecs > rec_limit:
+            # 2 is added to account for the enclosing `[]`
+            # and the separator `, ` between records.
+            recsize = len(json.dumps(rec, default=str)) + 2
+            recchars = str(rec) + 2
+            if any([
+                outsize + recsize > file_limit,
+                outchars + recchars > char_limit,
+                nrecs > rec_limit
+            ]):
                 batches.append(
                     self._add_batch(
                         job_id=job['id'],
@@ -223,15 +244,15 @@ class SFBulkType:
                     )
                 )
                 last_break = i
-                outsize, nrecs = 0, 0
+                nrecs, outsize, outchars = 0, 0, 0
         if last_break < len(data):
             batches.append(
-                    self._add_batch(
-                        job_id=job['id'],
-                        data=data[last_break:len(data)],
-                        operation=operation
-                    )
+                self._add_batch(
+                    job_id=job['id'],
+                    data=data[last_break:len(data)],
+                    operation=operation
                 )
+            )
         return batches
 
     # pylint: disable=R0913
@@ -251,7 +272,7 @@ class SFBulkType:
         # check for batch size type since now it accepts both integers
         # & the string `auto`
         if not (isinstance(batch_size, int) or batch_size == 'auto'):
-                raise ValueError('batch size should be auto or an integer')
+            raise ValueError('batch size should be auto or an integer')
 
         if operation not in ('query', 'queryAll'):
             # Checks to prevent batch limit
@@ -313,7 +334,12 @@ class SFBulkType:
 
     # _bulk_operation wrappers to expose supported Salesforce bulk operations
     def delete(self, data, batch_size=10000, use_serial=False):
-        """ soft delete records """
+        """ soft delete records
+
+        Data is batched by 10,000 records by default. To pick a lower size
+        pass smaller integer to `batch_size`. to let simple-salesforce pick
+        the appropriate limit dynamically, enter `batch_size='auto'`
+        """
         results = self._bulk_operation(use_serial=use_serial,
                                        operation='delete', data=data,
                                        batch_size=batch_size)
@@ -321,7 +347,12 @@ class SFBulkType:
 
     def insert(self, data, batch_size=10000,
                use_serial=False):
-        """ insert records """
+        """ insert records
+
+        Data is batched by 10,000 records by default. To pick a lower size
+        pass smaller integer to `batch_size`. to let simple-salesforce pick
+        the appropriate limit dynamically, enter `batch_size='auto'`
+        """
         results = self._bulk_operation(use_serial=use_serial,
                                        operation='insert', data=data,
                                        batch_size=batch_size)
@@ -329,7 +360,12 @@ class SFBulkType:
 
     def upsert(self, data, external_id_field, batch_size=10000,
                use_serial=False):
-        """ upsert records based on a unique identifier """
+        """ upsert records based on a unique identifier
+
+        Data is batched by 10,000 records by default. To pick a lower size
+        pass smaller integer to `batch_size`. to let simple-salesforce pick
+        the appropriate limit dynamically, enter `batch_size='auto'`
+        """
         results = self._bulk_operation(use_serial=use_serial,
                                        operation='upsert',
                                        external_id_field=external_id_field,
@@ -337,14 +373,24 @@ class SFBulkType:
         return results
 
     def update(self, data, batch_size=10000, use_serial=False):
-        """ update records """
+        """ update records
+
+        Data is batched by 10,000 records by default. To pick a lower size
+        pass smaller integer to `batch_size`. to let simple-salesforce pick
+        the appropriate limit dynamically, enter `batch_size='auto'`
+        """
         results = self._bulk_operation(use_serial=use_serial,
                                        operation='update', data=data,
                                        batch_size=batch_size)
         return results
 
     def hard_delete(self, data, batch_size=10000, use_serial=False):
-        """ hard delete records """
+        """ hard delete records
+
+        Data is batched by 10,000 records by default. To pick a lower size
+        pass smaller integer to `batch_size`. to let simple-salesforce pick
+        the appropriate limit dynamically, enter `batch_size='auto'`
+        """
         results = self._bulk_operation(use_serial=use_serial,
                                        operation='hardDelete', data=data,
                                        batch_size=batch_size)


### PR DESCRIPTION
closes: https://github.com/simple-salesforce/simple-salesforce/issues/470

creates dynamically sized batches to respect salesforce [API V1 Limits](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/bulk_common_limits.htm)

The following limits are respected when creating batches.

1. max file size 10MB
2. max number of records 10,000
3. max number of characters 10,000,000