### PR TITLE
Add optional flag use ordinary dict

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -8,9 +8,7 @@ import logging
 import re
 from collections import OrderedDict, namedtuple
 from urllib.parse import urljoin, urlparse
-
 import requests
-
 from .bulk import SFBulkHandler
 from .exceptions import SalesforceGeneralError
 from .login import SalesforceLogin
@@ -101,11 +99,8 @@ class Salesforce:
                      exposed by simple_salesforce.
         * parse_float -- Function to parse float values with. Is passed along to
                          https://docs.python.org/3/library/json.html#json.load
-        * object_pairs_hook -- Function that will be called with the result of 
-                               any object literal decoded with an ordered list
-                               of pairs. To use python 'dict' change it to None.
-                               Is passed along to
-                        https://docs.python.org/3/library/json.html#json.load
+        * object_pairs_hook -- Function to parse ordered list of pairs in json.
+                               To use python 'dict' change it to None or dict.
         """
 
         if domain is None:
@@ -683,11 +678,8 @@ class SFType:
                      exposed by simple_salesforce.
         * parse_float -- Function to parse float values with. Is passed along to
                          https://docs.python.org/3/library/json.html#json.load
-        * object_pairs_hook -- Function that will be called with the result of 
-                               any object literal decoded with an ordered list
-                               of pairs. To use python 'dict' change it to None.
-                               Is passed along to
-                        https://docs.python.org/3/library/json.html#json.load
+        * object_pairs_hook -- Function to parse ordered list of pairs in json.
+                               To use python 'dict' change it to None or dict.
         """
         self.session_id = session_id
         self.name = object_name

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -328,7 +328,7 @@ class Salesforce:
         url = self.base_url + path
         result = self._call_salesforce(method, url, name=path, params=params,
                                        **kwargs)
- 
+
         json_result = self.parse_result_to_json(result)
         if len(json_result) == 0:
             return None

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -52,6 +52,7 @@ class Salesforce:
             privatekey_file=None,
             privatekey=None,
             parse_float=None,
+            object_pairs_hook=OrderedDict
             ):
 
         """Initialize the instance with the given parameters.
@@ -99,6 +100,11 @@ class Salesforce:
                      exposed by simple_salesforce.
         * parse_float -- Function to parse float values with. Is passed along to
                          https://docs.python.org/3/library/json.html#json.load
+        * object_pairs_hook -- Function that will be called with the result of 
+                               any object literal decoded with an ordered list
+                               of pairs. To use python 'dict' change it to None.
+                               Is passed along to
+                        https://docs.python.org/3/library/json.html#json.load
         """
 
         if domain is None:
@@ -209,6 +215,7 @@ class Salesforce:
         self.tooling_url = '{base_url}tooling/'.format(base_url=self.base_url)
         self.api_usage = {}
         self._parse_float = parse_float
+        self._object_pairs_hook = object_pairs_hook
         self._mdapi = None
 
     @property
@@ -639,7 +646,7 @@ class Salesforce:
 
     def parse_result_to_json(self, result):
         """"Parse json from a Response object"""
-        return result.json(object_pairs_hook=OrderedDict,
+        return result.json(object_pairs_hook=self._object_pairs_hook,
                            parse_float=self._parse_float)
 
 
@@ -941,7 +948,7 @@ class SFType:
 
     def parse_result_to_json(self, result):
         """"Parse json from a Response object"""
-        return result.json(object_pairs_hook=OrderedDict,
+        return result.json(object_pairs_hook=self._dict,
                            parse_float=self._parse_float)
 
     def upload_base64(self, file_path, base64_field='Body', headers=None,

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -32,6 +32,7 @@ class Salesforce:
     for easy use of the Salesforce REST API.
     """
     _parse_float = None
+    _object_pairs_hook = OrderedDict
 
     # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
     def __init__(
@@ -653,6 +654,7 @@ class Salesforce:
 class SFType:
     """An interface to a specific type of SObject"""
     _parse_float = None
+    _object_pairs_hook = OrderedDict
 
     # pylint: disable=too-many-arguments
     def __init__(

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -52,7 +52,7 @@ class Salesforce:
             privatekey_file=None,
             privatekey=None,
             parse_float=None,
-            object_pairs_hook=OrderedDict
+            object_pairs_hook=OrderedDict,
             ):
 
         """Initialize the instance with the given parameters.
@@ -664,6 +664,7 @@ class SFType:
             proxies=None,
             session=None,
             parse_float=None,
+            object_pairs_hook=OrderedDict,
             ):
         """Initialize the instance with the given parameters.
 
@@ -680,6 +681,11 @@ class SFType:
                      exposed by simple_salesforce.
         * parse_float -- Function to parse float values with. Is passed along to
                          https://docs.python.org/3/library/json.html#json.load
+        * object_pairs_hook -- Function that will be called with the result of 
+                               any object literal decoded with an ordered list
+                               of pairs. To use python 'dict' change it to None.
+                               Is passed along to
+                        https://docs.python.org/3/library/json.html#json.load
         """
         self.session_id = session_id
         self.name = object_name
@@ -696,6 +702,7 @@ class SFType:
                                      sf_version=sf_version))
 
         self._parse_float = parse_float
+        self._object_pairs_hook = object_pairs_hook
 
     def metadata(self, headers=None):
         """Returns the result of a GET to `.../{object_name}/` as a dict
@@ -948,7 +955,7 @@ class SFType:
 
     def parse_result_to_json(self, result):
         """"Parse json from a Response object"""
-        return result.json(object_pairs_hook=self._dict,
+        return result.json(object_pairs_hook=self._object_pairs_hook,
                            parse_float=self._parse_float)
 
     def upload_base64(self, file_path, base64_field='Body', headers=None,

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -328,7 +328,7 @@ class Salesforce:
         url = self.base_url + path
         result = self._call_salesforce(method, url, name=path, params=params,
                                        **kwargs)
-
+ 
         json_result = self.parse_result_to_json(result)
         if len(json_result) == 0:
             return None

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -1166,7 +1166,7 @@ class TestSalesforce(unittest.TestCase):
             session=session,
         )
 
-        result = client.query('SELECT country, code FROM Account')
+        result = client.query('SELECT currency FROM Account')
         self.assertIsInstance(result, OrderedDict)
         self.assertEqual(result, OrderedDict({"currency": 1.0}))
 
@@ -1189,7 +1189,7 @@ class TestSalesforce(unittest.TestCase):
             object_pairs_hook=None,
         )
 
-        result = client.query('SELECT country, code FROM Account')
+        result = client.query('SELECT currency FROM Account')
         self.assertNotIsInstance(result, OrderedDict)
         self.assertIsInstance(result, dict)
         self.assertEqual(result, {"currency": 1.0})

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -1154,9 +1154,9 @@ class TestSalesforce(unittest.TestCase):
         responses.add(
             responses.GET,
             re.compile(
-                r'^https://.*/query/\?q=SELECT\+country,code\+FROM\+Account$'
+                r'^https://.*/query/\?q=SELECT\+currency\+FROM\+Account$'
             ),
-            body='{"US": "USD", "India": "INR"}',
+            body='{"currency": 1.0}',
             status=http.OK,
         )
         session = requests.Session()
@@ -1168,18 +1168,17 @@ class TestSalesforce(unittest.TestCase):
 
         result = client.query('SELECT country, code FROM Account')
         self.assertIsInstance(result, OrderedDict)
-        self.assertEqual(result, OrderedDict({"US": "USD", "India": "INR"}))
-        self.assertNotEqual(result, OrderedDict({"India": "INR", "US": "USD"}))
+        self.assertEqual(result, OrderedDict({"currency": 1.0}))
 
     @responses.activate
     def test_query_parse_json_to_Dict(self):
-        """Test querying generates float as Decimal values"""
+        """Test querying generates json as Dict"""
         responses.add(
             responses.GET,
             re.compile(
-                r'^https://.*/query/\?q=SELECT\+country,code\+FROM\+Account$'
+                r'^https://.*/query/\?q=SELECT\+currency\+FROM\+Account$'
             ),
-            body='{"US": "USD", "India": "INR"}',
+            body='{"currency": 1.0}',
             status=http.OK,
         )
         session = requests.Session()
@@ -1193,4 +1192,4 @@ class TestSalesforce(unittest.TestCase):
         result = client.query('SELECT country, code FROM Account')
         self.assertNotIsInstance(result, OrderedDict)
         self.assertIsInstance(result, dict)
-        self.assertEqual(result, {"India": "INR", "US": "USD"})
+        self.assertEqual(result, {"currency": 1.0})

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -1149,7 +1149,7 @@ class TestSalesforce(unittest.TestCase):
         self.assertNotEqual(result, {"currency": "1.0"})
 
     @responses.activate
-    def test_query_parse_json_to_OrderedDict(self):
+    def test_query_parse_json_to_ordered_dict(self):
         """Test querying generates output as OrderedDict by default"""
         responses.add(
             responses.GET,
@@ -1171,7 +1171,7 @@ class TestSalesforce(unittest.TestCase):
         self.assertEqual(result, OrderedDict({"currency": 1.0}))
 
     @responses.activate
-    def test_query_parse_json_to_Dict(self):
+    def test_query_parse_json_to_dict(self):
         """Test querying generates json as Dict"""
         responses.add(
             responses.GET,


### PR DESCRIPTION
closes: #477 
Issue: Flag for using an ordinary dict in the API response #477 raised by @brno32 
Situation: json output is being decoded as OrderedDict with no option to override it. Users who need to use dict need an option to change the json output to use dict.
Solution: create a option object_pairs_hook parameter whose default value is OrderedDict. Users can change it to use dict or keep it None since the by default json result will use dict if object_pairs_hook is None.
@jon-wobken 