### PR TITLE
Add exception for login and check login parameter types

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -122,7 +122,7 @@ class Salesforce:
 
         # Determine if the user wants to use our username/password auth or pass
         # in their own information
-        if all(arg is not None for arg in (
+        if all(arg is not None and type(arg) is str for arg in (
                 username, password, security_token)):
             self.auth_type = "password"
 
@@ -137,7 +137,7 @@ class Salesforce:
                 client_id=client_id,
                 domain=self.domain)
 
-        elif all(arg is not None for arg in (
+        elif all(arg is not None and type(arg) is str for arg in (
                 session_id, instance or instance_url)):
             self.auth_type = "direct"
             self.session_id = session_id
@@ -152,7 +152,7 @@ class Salesforce:
             else:
                 self.sf_instance = instance
 
-        elif all(arg is not None for arg in (
+        elif all(arg is not None and type(arg) is str for arg in (
                 username, password, organizationId)):
             self.auth_type = 'ipfilter'
 
@@ -182,7 +182,7 @@ class Salesforce:
                 domain=self.domain)
 
         else:
-            raise TypeError(
+            raise ValueError(
                 'You must provide login information or an instance and token'
                 )
 

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -46,7 +46,7 @@ class TestCreateInstance(unittest.TestCase):
         mock_login.return_value = ("1234", "https://na15.salesforce.com")
         
         # Should raise a value error since the all 3 username, password, and token are required
-        self.assertRaises(ValueError,  Salesforce, username="user", password="pass", security_token="token")
+        self.assertRaises(ValueError,  Salesforce, username="user", password="pass")
 
     @patch('simple_salesforce.login.soap_login')
     def test_username_password_invalid_token(self, mock_login):
@@ -56,7 +56,7 @@ class TestCreateInstance(unittest.TestCase):
         
         # Should raise a value error since the all 3 username, password, and token are required
         # and all should be string values 
-        self.assertRaises(ValueError,  Salesforce, username="user", password="pass", security_token="token")
+        self.assertRaises(ValueError,  Salesforce, username="user", password="pass", security_token=123)
 
 
     @patch('simple_salesforce.login.token_login')
@@ -66,14 +66,17 @@ class TestCreateInstance(unittest.TestCase):
         mock_login.return_value = ("1234", "https://na15.salesforce.com")
 
         # Should pass and not raise exception since all parameters are provided in correct format 
-        Salesforce(username="user", consumer_key="12ab34c", privatekey="34cd12")
+        Salesforce(username="user", consumer_key="16ed2757debf646833e8ce6c1fb9594841b167f659b8163c820ea0522924d6ba", privatekey="feae1c8ed273bff90e581e9aca3008e8024ba4cd4605c222c8b658cdb2a9dcbb")
 
 
     def test_empty(self):
         "No login parameters provided"
 
-        # Should raise exception for no paramaters provided
-        self.assertRaises(TypeError, Salesforce())  
+        try:
+            # Should raise exception for no paramaters provided
+            self.assertRaises(ValueError, Salesforce()) 
+        except ValueError:
+            pass
 
     
 

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -11,9 +11,71 @@ from urllib.parse import urlparse
 import requests
 import responses
 from simple_salesforce import tests
+from simple_salesforce.api import Salesforce
 from simple_salesforce.exceptions import SalesforceAuthenticationFailed
 from simple_salesforce.login import SalesforceLogin
 
+
+class TestCreateInstance(unittest.TestCase):
+    """
+    Test for the Salesforce SF Instance
+    These tests are mainly concerned with the the values passed in to the SF Class
+    when instantiated. We want to make sure that an appropiate exception is raised if
+    if incorrect login parameters are provided. 
+    """
+
+    # For these tests, we can patch the login methods uses for each one
+    # We are not concerened with the login response, but what happens
+    # when different parameters are provided for login, both valid and invalid 
+
+    # Adding these tests will make sure 
+
+    @patch('simple_salesforce.login.soap_login')
+    def test_username_password_token(self, mock_login):
+        "Valid user, pass, and token for soap login. Domain is optional."
+
+        mock_login.return_value = ("1234", "https://na15.salesforce.com")
+        
+        # Should not raise an exception
+        Salesforce(username="user", password="pass", security_token="token")
+
+    @patch('simple_salesforce.login.soap_login')
+    def test_username_password_missing_token(self, mock_login):
+        "Valid user, pass with missing token for soap login"
+
+        mock_login.return_value = ("1234", "https://na15.salesforce.com")
+        
+        # Should raise a value error since the all 3 username, password, and token are required
+        self.assertRaises(ValueError,  Salesforce, username="user", password="pass", security_token="token")
+
+    @patch('simple_salesforce.login.soap_login')
+    def test_username_password_invalid_token(self, mock_login):
+        "Valid user, pass with invalid token as int for soap login"
+
+        mock_login.return_value = ("1234", "https://na15.salesforce.com")
+        
+        # Should raise a value error since the all 3 username, password, and token are required
+        # and all should be string values 
+        self.assertRaises(ValueError,  Salesforce, username="user", password="pass", security_token="token")
+
+
+    @patch('simple_salesforce.login.token_login')
+    def test_username_consumerkey_privatekey(self, mock_login):
+        "Valid user, consumer key and private key"
+
+        mock_login.return_value = ("1234", "https://na15.salesforce.com")
+
+        # Should pass and not raise exception since all parameters are provided in correct format 
+        Salesforce(username="user", consumer_key="12ab34c", privatekey="34cd12")
+
+
+    def test_empty(self):
+        "No login parameters provided"
+
+        # Should raise exception for no paramaters provided
+        self.assertRaises(TypeError, Salesforce())  
+
+    
 
 class TestSalesforceLogin(unittest.TestCase):
     """Tests for the SalesforceLogin function"""


### PR DESCRIPTION
Summary:
There could be more helpful error checking when instantiating the Salesforce class with login parameters. Currently we only check if certain groups of parameters are provided to meet the requirements for different login methods and then send those to the /login API. However, we could add some additional checks when instantiating to indicate earlier if the credentials provided are incorrect (specifically the incorrect type) instead of waiting for the API to tell us the login was unsuccessful. For most parameters they need to be strings. 

Changes:
- Add tests for login functionality with different parameters
- Check for str type for login parameters
- Change exception to ValueError to better indicate login parameter error 
