### PR TITLE
Avoid a ZeroDivisionError in bulk.py

### DIFF
--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -278,7 +278,7 @@ class SFBulkType:
             # Checks if data is present
             if not data:
                 raise ValueError(f'data should not be empty for {operation}')
-                
+
             # Checks to prevent batch limit
             if batch_size != 'auto':
                 batch_size = min(batch_size, len(data), 10000)

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -275,6 +275,10 @@ class SFBulkType:
             raise ValueError('batch size should be auto or an integer')
 
         if operation not in ('query', 'queryAll'):
+            # Checks if data is present
+            if not data:
+                raise ValueError(f'data should not be empty for {operation}')
+                
             # Checks to prevent batch limit
             if batch_size != 'auto':
                 batch_size = min(batch_size, len(data), 10000)


### PR DESCRIPTION
The line

```for i in range((len(data) // batch_size + 1))] if i]```

Would give a ZeroDivisionError if `data` were to be empty. This code will raise an error if it's the case.

N.B. The check could possibly be pushed further up before either of the ifs. Would appreciate a comment on that.