### PR TITLE
fix: use unescaped username for JWT claim

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,9 @@ setup(
         },
 install_requires = [
                        'requests>=2.22.0',
-                       'pyjwt',
-                       'zeep'
+                       'cryptography',
+                       'zeep',
+                       'pyjwt'
                        ],
                    tests_require = [
                                        'pytest',

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -171,7 +171,7 @@ def SalesforceLogin(
         expiration = datetime.now(timezone.utc) + timedelta(minutes=3)
         payload = {
             'iss': consumer_key,
-            'sub': username,
+            'sub': unescape(username),
             'aud': f'https://{domain}.salesforce.com',
             'exp': f'{expiration.timestamp():.0f}'
             }


### PR DESCRIPTION
- [JWT Bearer Flow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm&type=5) needs JWT claim `sub` containing unescaped username
- [Connected App Login](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_username_password_flow.htm&type=5) has been fixed by #604