### PR TITLE
Allow passing other requests options to SFType methods

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -443,6 +443,7 @@ class Salesforce:
         * query -- the SOQL query to send to Salesforce, e.g.
                    SELECT Id FROM Lead WHERE Email = "waldo@somewhere.com"
         * include_deleted -- True if deleted records should be included
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
         url = self.base_url + ('queryAll/' if include_deleted else 'query/')
         params = {'q': query}
@@ -469,6 +470,7 @@ class Salesforce:
         * include_deleted -- True if the `next_records_identifier` refers to a
                              query that includes deleted records. Only used if
                              `identifier_is_url` is False
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
         if identifier_is_url:
             # Don't use `self.base_url` here because the full URI is provided
@@ -494,6 +496,7 @@ class Salesforce:
         * query -- the SOQL query to send to Salesforce, e.g.
                    SELECT Id FROM Lead WHERE Email = "waldo@somewhere.com"
         * include_deleted -- True if the query should include deleted records.
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
 
         result = self.query(query, include_deleted=include_deleted, **kwargs)
@@ -519,6 +522,7 @@ class Salesforce:
         * query -- the SOQL query to send to Salesforce, e.g.
                    SELECT Id FROM Lead WHERE Email = "waldo@somewhere.com"
         * include_deleted -- True if the query should include deleted records.
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
 
         records = self.query_all_iter(query, include_deleted=include_deleted,
@@ -745,58 +749,58 @@ class SFType:
             return self.salesforce.session_id
         return self._session_id
 
-    def metadata(self, headers=None):
+    def metadata(self, **kwargs):
         """Returns the result of a GET to `.../{object_name}/` as a dict
         decoded from the JSON payload returned by Salesforce.
         Arguments:
-        * headers -- a dict with additional request headers.
+        * arguments supported by requests.request (e.g. json, timeout)
         """
-        result = self._call_salesforce('GET', self.base_url, headers=headers)
+        result = self._call_salesforce('GET', self.base_url, **kwargs)
         return self.parse_result_to_json(result)
 
-    def describe(self, headers=None):
+    def describe(self, **kwargs):
         """Returns the result of a GET to `.../{object_name}/describe` as a
         dict decoded from the JSON payload returned by Salesforce.
         Arguments:
-        * headers -- a dict with additional request headers.
+        * arguments supported by requests.request (e.g. json, timeout)
         """
         result = self._call_salesforce(
             method='GET', url=urljoin(self.base_url, 'describe'),
-            headers=headers
+            **kwargs
             )
         return self.parse_result_to_json(result)
 
-    def describe_layout(self, record_id, headers=None):
+    def describe_layout(self, record_id, **kwargs):
         """Returns the layout of the object
         Returns the result of a GET to
         `.../{object_name}/describe/layouts/<recordid>` as a dict decoded from
         the JSON payload returned by Salesforce.
         Arguments:
         * record_id -- the Id of the SObject to get
-        * headers -- a dict with additional request headers.
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
         custom_url_part = f'describe/layouts/{record_id}'
         result = self._call_salesforce(
             method='GET',
             url=urljoin(self.base_url, custom_url_part),
-            headers=headers
+            **kwargs
             )
         return self.parse_result_to_json(result)
 
-    def get(self, record_id, headers=None):
+    def get(self, record_id, **kwargs):
         """Returns the result of a GET to `.../{object_name}/{record_id}` as a
         dict decoded from the JSON payload returned by Salesforce.
         Arguments:
         * record_id -- the Id of the SObject to get
-        * headers -- a dict with additional request headers.
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
         result = self._call_salesforce(
             method='GET', url=urljoin(self.base_url, record_id),
-            headers=headers
+            **kwargs
             )
         return self.parse_result_to_json(result)
 
-    def get_by_custom_id(self, custom_id_field, custom_id, headers=None):
+    def get_by_custom_id(self, custom_id_field, custom_id, **kwargs):
         """Return an ``SFType`` by custom ID
         Returns the result of a GET to
         `.../{object_name}/{custom_id_field}/{custom_id}` as a dict decoded
@@ -805,29 +809,29 @@ class SFType:
         * custom_id_field -- the API name of a custom field that was defined
                              as an External ID
         * custom_id - the External ID value of the SObject to get
-        * headers -- a dict with additional request headers.
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
         custom_url = urljoin(self.base_url, f'{custom_id_field}/{custom_id}')
         result = self._call_salesforce(
-            method='GET', url=custom_url, headers=headers
+            method='GET', url=custom_url, **kwargs
             )
         return self.parse_result_to_json(result)
 
-    def create(self, data, headers=None):
+    def create(self, data, **kwargs):
         """Creates a new SObject using a POST to `.../{object_name}/`.
         Returns a dict decoded from the JSON payload returned by Salesforce.
         Arguments:
         * data -- a dict of the data to create the SObject from. It will be
                   JSON-encoded before being transmitted.
-        * headers -- a dict with additional request headers.
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
         result = self._call_salesforce(
             method='POST', url=self.base_url,
-            data=json.dumps(data), headers=headers
+            data=json.dumps(data), **kwargs
             )
         return self.parse_result_to_json(result)
 
-    def upsert(self, record_id, data, raw_response=False, headers=None):
+    def upsert(self, record_id, data, raw_response=False, **kwargs):
         """Creates or updates an SObject using a PATCH to
         `.../{object_name}/{record_id}`.
         If `raw_response` is false (the default), returns the status code
@@ -840,15 +844,15 @@ class SFType:
                   will be JSON-encoded before being transmitted.
         * raw_response -- a boolean indicating whether to return the response
                           directly, instead of the status code.
-        * headers -- a dict with additional request headers.
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
         result = self._call_salesforce(
             method='PATCH', url=urljoin(self.base_url, record_id),
-            data=json.dumps(data), headers=headers
+            data=json.dumps(data), **kwargs
             )
         return self._raw_response(result, raw_response)
 
-    def update(self, record_id, data, raw_response=False, headers=None):
+    def update(self, record_id, data, raw_response=False, **kwargs):
         """Updates an SObject using a PATCH to
         `.../{object_name}/{record_id}`.
         If `raw_response` is false (the default), returns the status code
@@ -860,15 +864,15 @@ class SFType:
                   JSON-encoded before being transmitted.
         * raw_response -- a boolean indicating whether to return the response
                           directly, instead of the status code.
-        * headers -- a dict with additional request headers.
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
         result = self._call_salesforce(
             method='PATCH', url=urljoin(self.base_url, record_id),
-            data=json.dumps(data), headers=headers
+            data=json.dumps(data), **kwargs
             )
         return self._raw_response(result, raw_response)
 
-    def delete(self, record_id, raw_response=False, headers=None):
+    def delete(self, record_id, raw_response=False, **kwargs):
         """Deletes an SObject using a DELETE to
         `.../{object_name}/{record_id}`.
         If `raw_response` is false (the default), returns the status code
@@ -878,15 +882,15 @@ class SFType:
         * record_id -- the Id of the SObject to delete
         * raw_response -- a boolean indicating whether to return the response
                           directly, instead of the status code.
-        * headers -- a dict with additional request headers.
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
         result = self._call_salesforce(
             method='DELETE', url=urljoin(self.base_url, record_id),
-            headers=headers
+            **kwargs
             )
         return self._raw_response(result, raw_response)
 
-    def deleted(self, start, end, headers=None):
+    def deleted(self, start, end, **kwargs):
         # pylint: disable=line-too-long
         """Gets a list of deleted records
         Use the SObject Get Deleted resource to get a list of deleted records
@@ -895,16 +899,16 @@ class SFType:
         +00:00
         * start -- start datetime object
         * end -- end datetime object
-        * headers -- a dict with additional request headers.
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
         url = urljoin(
             self.base_url,
             f'deleted/?start={date_to_iso8601(start)}&end={date_to_iso8601(end)}'
             )
-        result = self._call_salesforce(method='GET', url=url, headers=headers)
+        result = self._call_salesforce(method='GET', url=url, **kwargs)
         return self.parse_result_to_json(result)
 
-    def updated(self, start, end, headers=None):
+    def updated(self, start, end, **kwargs):
         # pylint: disable=line-too-long
         """Gets a list of updated records
         Use the SObject Get Updated resource to get a list of updated
@@ -913,13 +917,13 @@ class SFType:
          +00:00
         * start -- start datetime object
         * end -- end datetime object
-        * headers -- a dict with additional request headers.
+        * other arguments supported by requests.request (e.g. json, timeout)
         """
         url = urljoin(
             self.base_url,
             f'updated/?start={date_to_iso8601(start)}&end={date_to_iso8601(end)}'
             )
-        result = self._call_salesforce(method='GET', url=url, headers=headers)
+        result = self._call_salesforce(method='GET', url=url, **kwargs)
         return self.parse_result_to_json(result)
 
     def _call_salesforce(self, method, url, **kwargs):

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -72,6 +72,22 @@ class TestSFType(unittest.TestCase):
         self.assertEqual(sf_type.metadata(), {})
 
     @responses.activate
+    def test_metadata_with_timeout(self):
+        """Ensure metadata works with other requests kwargs"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*$'),
+            body='{}',
+            status=http.OK
+            )
+
+        sf_type = _create_sf_type()
+        sf_type.metadata(timeout=3)
+        timeout = responses.calls[0].request.req_kwargs['timeout']
+        self.assertEqual(timeout, 3)
+
+
+    @responses.activate
     def test_describe_with_additional_request_headers(self):
         """Ensure custom headers are used for describe requests"""
         responses.add(
@@ -104,6 +120,22 @@ class TestSFType(unittest.TestCase):
         sf_type = _create_sf_type()
 
         self.assertEqual(sf_type.describe(), {})
+
+    @responses.activate
+    def test_describe_with_timeout(self):
+        """Ensure describe works with other requests kwargs"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*/Case/describe$'),
+            body='{}',
+            status=http.OK
+            )
+
+        sf_type = _create_sf_type()
+        sf_type.describe(timeout=1)
+        timeout = responses.calls[0].request.req_kwargs['timeout']
+        self.assertEqual(timeout, 1)
+
 
     @responses.activate
     def test_describe_layout_with_additional_request_headers(self):
@@ -141,6 +173,21 @@ class TestSFType(unittest.TestCase):
         self.assertEqual(sf_type.describe_layout(record_id='444'), {})
 
     @responses.activate
+    def test_describe_layout_with_timeout(self):
+        """Ensure describe_layout works with other requests kwargs"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*/Case/describe/layouts/445$'),
+            body='{}',
+            status=http.OK
+            )
+
+        sf_type = _create_sf_type()
+        sf_type.describe_layout(record_id='445', timeout=10)
+        timeout = responses.calls[0].request.req_kwargs['timeout']
+        self.assertEqual(timeout, 10)
+
+    @responses.activate
     def test_get_with_additional_request_headers(self):
         """Ensure custom headers are used for get requests"""
         responses.add(
@@ -174,6 +221,21 @@ class TestSFType(unittest.TestCase):
         sf_type = _create_sf_type()
 
         self.assertEqual(sf_type.get(record_id='444'), {})
+
+    @responses.activate
+    def test_get_with_timeout(self):
+        """Ensure get works with other requests kwargs"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*/Case/445$'),
+            body='{}',
+            status=http.OK
+            )
+
+        sf_type = _create_sf_type()
+        sf_type.get(record_id='445', timeout=8)
+        timeout = responses.calls[0].request.req_kwargs['timeout']
+        self.assertEqual(timeout, 8)
 
     @responses.activate
     def test_get_by_custom_id_with_additional_request_headers(self):
@@ -216,6 +278,25 @@ class TestSFType(unittest.TestCase):
         self.assertEqual(result, {})
 
     @responses.activate
+    def test_get_by_custom_id_with_timeout(self):
+        """Ensure get_by_custom_id works with other requests kwargs"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*/Case/some-field/445$'),
+            body='{}',
+            status=http.OK
+            )
+
+        sf_type = _create_sf_type()
+        sf_type.get_by_custom_id(
+            custom_id_field='some-field',
+            custom_id='445',
+            timeout=9
+            )
+        timeout = responses.calls[0].request.req_kwargs['timeout']
+        self.assertEqual(timeout, 9)
+
+    @responses.activate
     def test_create_with_additional_request_headers(self):
         """Ensure custom headers are used for create requests"""
         responses.add(
@@ -250,6 +331,21 @@ class TestSFType(unittest.TestCase):
         result = sf_type.create(data={'some': 'data'})
 
         self.assertEqual(result, {})
+
+    @responses.activate
+    def test_create_with_timeout(self):
+        """Ensure create works with other requests kwargs"""
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://.*/Case/$'),
+            body='{}',
+            status=http.OK
+            )
+
+        sf_type = _create_sf_type()
+        sf_type.create(data={'some': 'data'}, timeout=12)
+        timeout = responses.calls[0].request.req_kwargs['timeout']
+        self.assertEqual(timeout, 12)
 
     @responses.activate
     def test_update_with_additional_request_headers(self):
@@ -292,6 +388,25 @@ class TestSFType(unittest.TestCase):
         self.assertEqual(result, http.OK)
 
     @responses.activate
+    def test_update_with_timeout(self):
+        """Ensure update works with other requests kwargs"""
+        responses.add(
+            responses.PATCH,
+            re.compile(r'^https://.*/Case/some-case-id$'),
+            body='{}',
+            status=http.OK
+            )
+
+        sf_type = _create_sf_type()
+        sf_type.update(
+            record_id='some-case-id',
+            data={'some': 'data'},
+            timeout=11
+            )
+        timeout = responses.calls[0].request.req_kwargs['timeout']
+        self.assertEqual(timeout, 11)
+
+    @responses.activate
     def test_upsert_with_additional_request_headers(self):
         """Ensure custom headers are used for upserts"""
         responses.add(
@@ -332,6 +447,25 @@ class TestSFType(unittest.TestCase):
         self.assertEqual(result, http.OK)
 
     @responses.activate
+    def test_upsert_with_timeout(self):
+        """Ensure upsert works with other requests kwargs"""
+        responses.add(
+            responses.PATCH,
+            re.compile(r'^https://.*/Case/some-case-id$'),
+            body='{}',
+            status=http.OK
+            )
+
+        sf_type = _create_sf_type()
+        sf_type.upsert(
+            record_id='some-case-id',
+            data={'some': 'data'},
+            timeout=13
+            )
+        timeout = responses.calls[0].request.req_kwargs['timeout']
+        self.assertEqual(timeout, 13)
+
+    @responses.activate
     def test_delete_with_additional_request_headers(self):
         """Ensure custom headers are used for deletes"""
         responses.add(
@@ -366,6 +500,21 @@ class TestSFType(unittest.TestCase):
         result = sf_type.delete(record_id='some-case-id')
 
         self.assertEqual(result, http.OK)
+
+    @responses.activate
+    def test_delete_with_timeout(self):
+        """Ensure deleted works with other requests kwargs"""
+        responses.add(
+            responses.DELETE,
+            re.compile(r'^https://.*/Case/some-case-id$'),
+            body='{}',
+            status=http.OK
+            )
+
+        sf_type = _create_sf_type()
+        sf_type.delete(record_id='some-case-id', timeout=5)
+        timeout = responses.calls[0].request.req_kwargs['timeout']
+        self.assertEqual(timeout, 5)
 
     @responses.activate
     def test_deleted_with_additional_request_headers(self):
@@ -405,6 +554,23 @@ class TestSFType(unittest.TestCase):
         self.assertEqual(result, {})
 
     @responses.activate
+    def test_deleted_with_timeout(self):
+        """Ensure deleted works with other requests kwargs"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*/Case/deleted/\?start=.+&end=.+$'),
+            body='{}',
+            status=http.OK
+            )
+
+        sf_type = _create_sf_type()
+        sf_type.deleted(
+            start=datetime.now(), end=datetime.now(), timeout=5)
+        timeout = responses.calls[0].request.req_kwargs['timeout']
+        self.assertEqual(timeout, 5)
+
+
+    @responses.activate
     def test_updated_with_additional_request_headers(self):
         """Ensure custom headers are used for updated"""
         responses.add(
@@ -440,6 +606,23 @@ class TestSFType(unittest.TestCase):
             start=datetime.now(), end=datetime.now())
 
         self.assertEqual(result, {})
+
+    @responses.activate
+    def test_updated_with_timeout(self):
+        """Ensure updated works with other requests kwargs"""
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://.*/Case/updated/\?start=.+&end=.+$'),
+            body='{}',
+            status=http.OK
+            )
+
+        sf_type = _create_sf_type()
+        sf_type.updated(
+            start=datetime.now(), end=datetime.now(), timeout=4)
+        timeout = responses.calls[0].request.req_kwargs['timeout']
+        self.assertEqual(timeout, 4)
+
 
     @responses.activate
     def test_get_parse_float_as_float(self):


### PR DESCRIPTION
This allows passing other requests options (like timeout) to all methods on SFType that make requests. Previously this was supported on some, but not all methods.

This duplicates #149 which has merge conflicts and hasn't been updated in some time and should fix #148.