### PR TITLE
Updated __getattr__ function to create SFType object with object_pair…

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -319,7 +319,8 @@ class Salesforce:
 
         return SFType(
             name, self.session_id, self.sf_instance, sf_version=self.sf_version,
-            proxies=self.proxies, session=self.session, salesforce=self)
+            proxies=self.proxies, session=self.session, salesforce=self, 
+            object_pairs_hook=self.object_pairs_hook)
 
     # User utility methods
     def set_password(self, user, password):


### PR DESCRIPTION
…s_hook as input

Right now let us say that the user creates a SFType object using __getattr__ function which is present in the class SalesForce. If the SalesForce object is initiated using object_pairs_hook being dict or print. In that case the user would want the response from SFType to be same as that object as well. So I have added object_pairs_hook in the SFType object which is being called in the __getattr__ function of the SalesForce Class