### PR TITLE
Updated __getattr__ function to create SFType object with object_pairs_hook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,9 @@ setup(
         },
 install_requires = [
                        'requests>=2.22.0',
-                       'pyjwt',
-                       'zeep'
+                       'cryptography',
+                       'zeep',
+                       'pyjwt'
                        ],
                    tests_require = [
                                        'pytest',

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -319,7 +319,8 @@ class Salesforce:
 
         return SFType(
             name, self.session_id, self.sf_instance, sf_version=self.sf_version,
-            proxies=self.proxies, session=self.session, salesforce=self)
+            proxies=self.proxies, session=self.session, salesforce=self, 
+            object_pairs_hook=self.object_pairs_hook)
 
     # User utility methods
     def set_password(self, user, password):

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -319,7 +319,7 @@ class Salesforce:
 
         return SFType(
             name, self.session_id, self.sf_instance, sf_version=self.sf_version,
-            proxies=self.proxies, session=self.session, salesforce=self, 
+            proxies=self.proxies, session=self.session, salesforce=self,
             object_pairs_hook=self._object_pairs_hook)
 
     # User utility methods

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -320,7 +320,7 @@ class Salesforce:
         return SFType(
             name, self.session_id, self.sf_instance, sf_version=self.sf_version,
             proxies=self.proxies, session=self.session, salesforce=self, 
-            object_pairs_hook=self.object_pairs_hook)
+            object_pairs_hook=self._object_pairs_hook)
 
     # User utility methods
     def set_password(self, user, password):


### PR DESCRIPTION
Right now let us say that the user creates a SFType object using getattr function which is present in the class SalesForce. If the SalesForce object is initiated using object_pairs_hook being dict or print. In that case the user would want the response from SFType to be same as that object as well. So I have added object_pairs_hook in the SFType object which is being called in the getattr function of the SalesForce Class