### PR TITLE
Fix typo in main README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -443,7 +443,7 @@ Update existing records:
 
     sf.bulk.Contact.update(data,batch_size=10000,use_serial=True)
     
- Update existing records and update lookup fields from an external id field:
+Update existing records and update lookup fields from an external id field:
 
 .. code-block:: python
 


### PR DESCRIPTION
This PR fixes a small typo in the README that is causing funny formatting of the bulk section.
