### PR TITLE
Update: Added `as_json` param to `Salesforce.restful`

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -349,7 +349,7 @@ class Salesforce:
         return self.parse_result_to_json(result)
 
     # Generic Rest Function
-    def restful(self, path, params=None, method='GET', **kwargs):
+    def restful(self, path, params=None, method='GET', as_json=True, **kwargs):
         """Allows you to make a direct REST call if you know the path
 
         Arguments:
@@ -357,18 +357,18 @@ class Salesforce:
             Example: sobjects/User/ABC123/password'
         * params: dict of parameters to pass to the path
         * method: HTTP request method, default GET
+        * as_json: boolean indicating whether to apply 'parse_result_to_json'
+            method to result
         * other arguments supported by requests.request (e.g. json, timeout)
         """
 
         url = self.base_url + path
         result = self._call_salesforce(method, url, name=path, params=params,
                                        **kwargs)
-
-        json_result = self.parse_result_to_json(result)
-        if len(json_result) == 0:
-            return None
-
-        return json_result
+        result = self.parse_result_to_json(result) if as_json else result.text
+        if not result:
+            return
+        return result
 
     # OAuth Endpoints Function
     def oauth2(self, path, params=None, method='GET'):


### PR DESCRIPTION
When requesting an event log file using `Salesforce.restful` (which returns CSV data), you receive a `JSONDecodeError`. By including the suggested param, you can bypass JSON deserialization.

Example workaround that would be handled by new param:
```python
import os

from simple_salesforce import Salesforce

LOG_FILE_PATH = 'sobjects/EventLogFile/xxxxxxxxxxxxxxxxxx/LogFile'

salesforce_conn = Salesforce(
    username=os.environ['SALESFORCE_USERNAME'],
    password=os.environ['SALESFORCE_PASSWORD'],
    security_token=os.environ['SALESFORCE_SECURITY_TOKEN'],
    instance_url=os.environ['SALESFORCE_INSTANCE_URL']
)

# returns CSV data without any error
result = salesforce_conn._call_salesforce(
    method='GET',
    url=salesforce_conn.base_url + LOG_FILE_PATH,
    name=LOG_FILE_PATH
)
```