### PR TITLE
Add OAuth 2.0 client credentials login

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -212,7 +212,18 @@ class Salesforce:
                 proxies=self.proxies,
                 domain=self.domain)
             self._refresh_session()
-
+        elif all(arg is not None for arg in(
+            consumer_key, consumer_secret, domain
+        )):
+            self.auth_type = "client-credentials"
+            self._salesforce_login_partial = partial(
+                SalesforceLogin,
+                session=self.session,
+                consumer_key=consumer_key,
+                consumer_secret=consumer_secret,
+                proxies=self.proxies,
+                domain=self.domain)
+            self._refresh_session()
         else:
             raise TypeError(
                 'You must provide login information or an instance and token'

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -2,6 +2,7 @@
 
 Heavily Modified from RestForce 1.0.0
 """
+import base64
 
 DEFAULT_CLIENT_ID_PREFIX = 'simple-salesforce'
 
@@ -190,6 +191,18 @@ def SalesforceLogin(
             f'https://{domain}.salesforce.com/services/oauth2/token',
             token_data, domain, consumer_key,
             None, proxies, session)
+    elif consumer_key is not None and consumer_secret is not None and \
+            domain is not None and domain not in ('login', 'test'):
+        token_data = {'grant_type': 'client_credentials'}
+        authorization = f'{consumer_key}:{consumer_secret}'
+        encoded = base64.b64encode(authorization.encode()).decode()
+        headers = {
+            'Authorization': f'Basic {encoded}'
+        }
+        return token_login(
+            f'https://{domain}.salesforce.com/services/oauth2/token',
+            token_data, domain, consumer_key,
+            headers, proxies, session)
     else:
         except_code = 'INVALID AUTH'
         except_msg = (

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -257,3 +257,15 @@ class TestSalesforceLogin(unittest.TestCase):
                 consumer_secret='12345.abcde'
                 )
         self.assertTrue(self.mockrequest.post.called)
+
+    @responses.activate
+    def test_connected_app_client_credentials_login_success(self):
+        """Test a successful connected app login with client credentials"""
+        login_args = {
+            'consumer_key': '12345.abcde',
+            'consumer_secret': '12345.abcde',
+            'domain': urlparse(tests.INSTANCE_URL).netloc.removesuffix('.salesforce.com'),
+            }
+        self._test_login_success(
+            re.compile(rf'^{tests.INSTANCE_URL}/.*$'), login_args,
+            response_body=tests.TOKEN_LOGIN_RESPONSE_SUCCESS)


### PR DESCRIPTION
Salesforce has recently started support for client credentials as a login method. It'll assign all scopes configured for the app to the token with some exceptions (notably: full, web, offline_access, refresh_token).

More info in the Salesforce documentation:
https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&type=5