### PR TITLE
Adding utf-8 encoding when performing bulk2 data uploads.

### DIFF
--- a/simple_salesforce/bulk2.py
+++ b/simple_salesforce/bulk2.py
@@ -508,7 +508,7 @@ class _Bulk2Client:
             method="PUT",
             session=self.session,
             headers=headers,
-            data=data,
+            data=data.encode("utf-8"),
             )
         if result.status_code != http.CREATED:
             raise SalesforceBulkV2LoadError(


### PR DESCRIPTION
Issue that I run into when running bulk2 upsert with utf8 characters:

```bash
'latin-1' codec can't encode character '\u2122' in position 4304: Body ('™') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
```

Based on the stackoverflow answer [here](https://stackoverflow.com/a/65582199). It looks like encoding into bytes will resolve this issue.

I also noticed this another PR for this repo:
https://github.com/simple-salesforce/simple-salesforce/pull/677/files#diff-7cc1f22706aaa3106749319adf03fe8a841ae6405862c0a01a849dcdf27c8df4R515-R516
