### PR TITLE
fix bulk2 upload and download utf-8 encoding errors.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'pytest',
         'pytz>=2014.1.1',
         'responses>=0.5.1',
-        'cryptography<3.4',
+        'cryptography>4.0.0',
         ],
     test_suite='simple_salesforce.tests',
     keywords=about['__keywords__'],

--- a/simple_salesforce/bulk2.py
+++ b/simple_salesforce/bulk2.py
@@ -231,7 +231,7 @@ class _Bulk2Client:
     """Bulk 2.0 API client"""
 
     JSON_CONTENT_TYPE = "application/json"
-    CSV_CONTENT_TYPE = "text/csv"
+    CSV_CONTENT_TYPE = "text/csv; charset=UTF-8"
 
     DEFAULT_WAIT_TIMEOUT_SECONDS = 86400  # 24-hour bulk job running time
     MAX_CHECK_INTERVAL_SECONDS = 2.0
@@ -429,7 +429,7 @@ class _Bulk2Client:
         return {
             "locator": locator,
             "number_of_records": number_of_records,
-            "records": self.filter_null_bytes(result.text),
+            "records": self.filter_null_bytes(result.content.decode('utf-8')),
             }
 
     def download_job_data(
@@ -508,7 +508,7 @@ class _Bulk2Client:
             method="PUT",
             session=self.session,
             headers=headers,
-            data=data,
+            data=data.encode("utf-8"),
             )
         if result.status_code != http.CREATED:
             raise SalesforceBulkV2LoadError(


### PR DESCRIPTION
Changes to correct the utf-8 encoding issues with the new Bulk2 implementation. Merging into Master since a version 1.12.6 branch has not yet been created.

1) Add charset=UTF-8 specification to the CSV_CONTENT_TYPE header to ensure proper request encoding/decoding across all Bulk2 Operations

2) When downloading results... Access results.content instead of results.text. Results.content byte stream is encoded as utf-8 and can then be properly decoded and returned as a string. 

- Currently, results are returned decoded as latin1 and requires data with special characters be re-encoded as latin1 and decoded as utf-8.

3) When uploading data... Encode the body to utf-8.

Fixes #687 