### PR TITLE
Handle non-XML responses during error conditions

### DIFF
--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from html import escape, unescape
 from json.decoder import JSONDecodeError
 from pathlib import Path
+from xml.parsers.expat import ExpatError
 
 import requests
 import jwt
@@ -228,10 +229,14 @@ def soap_login(soap_url, request_body, headers, proxies, session=None):
         soap_url, request_body, headers=headers, proxies=proxies)
 
     if response.status_code != 200:
-        except_code = getUniqueElementValueFromXmlString(
-            response.content, 'sf:exceptionCode')
-        except_msg = getUniqueElementValueFromXmlString(
-            response.content, 'sf:exceptionMessage')
+        try:
+            except_code = getUniqueElementValueFromXmlString(
+                response.content, 'sf:exceptionCode')
+            except_msg = getUniqueElementValueFromXmlString(
+                response.content, 'sf:exceptionMessage')
+        except ExpatError:
+            except_code = response.status_code
+            except_msg = response.content
         raise SalesforceAuthenticationFailed(except_code, except_msg)
 
     session_id = getUniqueElementValueFromXmlString(


### PR DESCRIPTION
```
  File "/home/web/project/env/lib/python3.10/site-packages/simple_salesforce/api.py", line 146, in __init__
    self._refresh_session()
  File "/home/web/project/env/lib/python3.10/site-packages/simple_salesforce/api.py", line 283, in _refresh_session
    self.session_id, self.sf_instance = self._salesforce_login_partial()
  File "/home/web/project/env/lib/python3.10/site-packages/simple_salesforce/login.py", line 221, in SalesforceLogin
    return soap_login(soap_url, login_soap_request_body,
  File "/home/web/project/env/lib/python3.10/site-packages/simple_salesforce/login.py", line 231, in soap_login
    except_code = getUniqueElementValueFromXmlString(
  File "/home/web/project/env/lib/python3.10/site-packages/simple_salesforce/util.py", line 21, in getUniqueElementValueFromXmlString
    xmlStringAsDom = xml.dom.minidom.parseString(xmlString)
  File "/usr/lib/python3.10/xml/dom/minidom.py", line 2000, in parseString
    return expatbuilder.parseString(string)
  File "/usr/lib/python3.10/xml/dom/expatbuilder.py", line 925, in parseString
    return builder.parseString(string)
  File "/usr/lib/python3.10/xml/dom/expatbuilder.py", line 223, in parseString
    parser.Parse(string, True)
xml.parsers.expat.ExpatError: syntax error: line 1, column 0
```

Where `string` == "upstream connect error or disconnect/reset before headers. reset reason: connection termination"