### PR TITLE
Include "fields" as a query param in GET requests

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -1026,10 +1026,8 @@ class SFType:
         * record_id -- the Id of the SObject to get
         * headers -- a dict with additional request headers.
         """
-        record_url = urljoin(self.base_url, record_id)
-
         result = self._call_salesforce(
-            method='GET', url=record_url,
+            method='GET', url=urljoin(self.base_url, record_id),
             headers=headers, **kwargs
             )
         return self.parse_result_to_json(result)
@@ -1050,7 +1048,7 @@ class SFType:
                              as an External ID
         * custom_id - the External ID value of the SObject to get
         * headers -- a dict with additional request headers.
-         """
+        """
         custom_url = urljoin(self.base_url,
                              f'{custom_id_field}/{custom_id}'
                              )

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -800,20 +800,26 @@ class SFType:
             )
         return self.parse_result_to_json(result)
 
-    def get(self, record_id, headers=None):
+    def get(self, record_id, headers=None, fields=None):
         """Returns the result of a GET to `.../{object_name}/{record_id}` as a
         dict decoded from the JSON payload returned by Salesforce.
         Arguments:
         * record_id -- the Id of the SObject to get
         * headers -- a dict with additional request headers.
+        * fields -- a string with the specific fields to get
         """
+        record_url = urljoin(self.base_url, record_id)
+
+        if fields:
+            record_url += f'?fields={fields}'
+
         result = self._call_salesforce(
-            method='GET', url=urljoin(self.base_url, record_id),
+            method='GET', url=record_url,
             headers=headers
             )
         return self.parse_result_to_json(result)
 
-    def get_by_custom_id(self, custom_id_field, custom_id, headers=None):
+    def get_by_custom_id(self, custom_id_field, custom_id, headers=None, fields=None):
         """Return an ``SFType`` by custom ID
         Returns the result of a GET to
         `.../{object_name}/{custom_id_field}/{custom_id}` as a dict decoded
@@ -823,8 +829,13 @@ class SFType:
                              as an External ID
         * custom_id - the External ID value of the SObject to get
         * headers -- a dict with additional request headers.
+        * fields -- a string with the specific fields to get
         """
         custom_url = urljoin(self.base_url, f'{custom_id_field}/{custom_id}')
+
+        if fields:
+            custom_url += f'?fields={fields}'
+
         result = self._call_salesforce(
             method='GET', url=custom_url, headers=headers
             )

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -1027,8 +1027,10 @@ class SFType:
         * headers -- a dict with additional request headers.
         """
         result = self._call_salesforce(
-            method='GET', url=urljoin(self.base_url, record_id),
-            headers=headers, **kwargs
+            method='GET',
+            url=urljoin(self.base_url, record_id),
+            headers=headers,
+            **kwargs
             )
         return self.parse_result_to_json(result)
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -800,27 +800,23 @@ class SFType:
             )
         return self.parse_result_to_json(result)
 
-    def get(self, record_id, headers=None, fields=None):
+    def get(self, record_id, headers=None, **kwargs):
         """Returns the result of a GET to `.../{object_name}/{record_id}` as a
         dict decoded from the JSON payload returned by Salesforce.
         Arguments:
         * record_id -- the Id of the SObject to get
         * headers -- a dict with additional request headers.
-        * fields -- a string with the specific fields to get
         """
         record_url = urljoin(self.base_url, record_id)
 
-        if fields:
-            record_url += f'?fields={fields}'
-
         result = self._call_salesforce(
             method='GET', url=record_url,
-            headers=headers
+            headers=headers, **kwargs
             )
         return self.parse_result_to_json(result)
 
     def get_by_custom_id(self, custom_id_field, custom_id, headers=None,
-                          fields=None):
+                          **kwargs):
         """Return an ``SFType`` by custom ID
         Returns the result of a GET to
         `.../{object_name}/{custom_id_field}/{custom_id}` as a dict decoded
@@ -830,15 +826,11 @@ class SFType:
                              as an External ID
         * custom_id - the External ID value of the SObject to get
         * headers -- a dict with additional request headers.
-        * fields -- a string with the specific fields to get
-        """
+         """
         custom_url = urljoin(self.base_url, f'{custom_id_field}/{custom_id}')
 
-        if fields:
-            custom_url += f'?fields={fields}'
-
         result = self._call_salesforce(
-            method='GET', url=custom_url, headers=headers
+            method='GET', url=custom_url, headers=headers, **kwargs
             )
         return self.parse_result_to_json(result)
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -819,7 +819,8 @@ class SFType:
             )
         return self.parse_result_to_json(result)
 
-    def get_by_custom_id(self, custom_id_field, custom_id, headers=None, fields=None):
+    def get_by_custom_id(self, custom_id_field, custom_id, headers=None,
+                          fields=None):
         """Return an ``SFType`` by custom ID
         Returns the result of a GET to
         `.../{object_name}/{custom_id_field}/{custom_id}` as a dict decoded


### PR DESCRIPTION
Salesforce REST API allows us to specify the fields of a record we want to retrieve.

Example extracted from their [documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_get_field_values.htm):

`curl https://MyDomainName.my.salesforce.com/services/data/v59.0/sobjects/Account/001D000000INjVe​?fields=AccountNumber,BillingPostalCode -H "Authorization: Bearer token"`

I've added a new "fields" argument on both methods from SFType: `get() & get_by_custom_id()`. So, if we want to retrieve data of certainn  this allows us to retrieve the data of that fields. For instance:

`salesforce_instance.Account.get('001D000000INjVe', fields="AccountNumber,BillingPostalCode")`

This is an optional argument, so if fields=None, the response will include all the fields of that SFType.

