### PR TITLE
Allow Non-Standard Domain in JWT for GovCloud

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -205,6 +205,7 @@ class Salesforce:
                 SalesforceLogin,
                 session=self.session,
                 username=username,
+                instance_url=instance_url,
                 consumer_key=consumer_key,
                 privatekey_file=privatekey_file,
                 privatekey=privatekey,

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -31,6 +31,7 @@ def SalesforceLogin(
         session=None,
         client_id=None,
         domain=None,
+        instance_url=None,
         consumer_key=None,
         consumer_secret=None,
         privatekey_file=None,
@@ -169,6 +170,7 @@ def SalesforceLogin(
     elif username is not None and \
             consumer_key is not None and \
             (privatekey_file is not None or privatekey is not None):
+        token_domain = instance_url if instance_url is not None else domain
         expiration = datetime.now(timezone.utc) + timedelta(minutes=3)
         payload = {
             'iss': consumer_key,
@@ -188,7 +190,7 @@ def SalesforceLogin(
             }
 
         return token_login(
-            f'https://{domain}.salesforce.com/services/oauth2/token',
+            f'https://{token_domain}.salesforce.com/services/oauth2/token',
             token_data, domain, consumer_key,
             None, proxies, session)
     elif consumer_key is not None and consumer_secret is not None and \


### PR DESCRIPTION
Authentication works slightly different for GovCloud instances of Salesforce which is outlined [here](https://help.salesforce.com/s/articleView?id=000386092&type=1). In summary there are two main differences that come into play here:
1. You are not able to login via login.salesforce.com and test.salesforce.com and are required to use MyDomain.salesforce.com
2. For JWT, you are required to hit the MyDomain.my.salesforce.com endpoint for generating the OAuth token, but still required to pass login.salesforce.com / test.salesforce.com in the "aud" parameter of the JWT.

The current implementation for JWT does not support passing the domain and instance URLs for JWT, which means it doesn't work at all when attempting to use JWT for GovCloud instances and throws an `invalid_grant: user hasn't approved this consumer` error. Being able to specify both fixes this problem.

Adding this change allows you to specify "test" or "login" for the domain parameter and then include your MyDomain URL for the instance URL and pass authentication as expected:
```
sf = Salesforce(
        username=username,
        consumer_key=consumer_key,
        privatekey_file=private_key_file,
        domain='login',
        instance_url='govcloudorg.my'
    )
```