### PR TITLE
Small typing annotation fixes

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -1,5 +1,6 @@
 """Core classes and exceptions for Simple-Salesforce"""
 
+from __future__ import annotations
 from datetime import datetime
 
 # has to be defined prior to login import
@@ -345,7 +346,7 @@ class Salesforce:
     def __getattr__(
             self,
             name: str
-            ) -> Union[SFBulkHandler, SFBulk2Handler, "SFType"]:
+            ) -> Union[SFBulkHandler, SFBulk2Handler, SFType]:
         """Returns an `SFType` instance for the given Salesforce object type
         (given in `name`).
         The magic part of the SalesforceAPI, this function translates

--- a/simple_salesforce/exceptions.py
+++ b/simple_salesforce/exceptions.py
@@ -1,5 +1,5 @@
 """All exceptions for Simple Salesforce"""
-from typing import Union
+from typing import Any, Union
 
 
 class SalesforceError(Exception):
@@ -13,7 +13,8 @@ class SalesforceError(Exception):
             url: str,
             status: int,
             resource_name: str,
-            content: bytes):
+            # `content` is populated by `requests.Response.json()` or `requests.Response.text` as a fallback
+            content: Any):
         """Initialize the SalesforceError exception
 
         SalesforceError is the base class of exceptions in simple-salesforce


### PR DESCRIPTION
Small fixes for the typing annotations added in https://github.com/simple-salesforce/simple-salesforce/pull/660.

It looks like the above PR included the string literal `'SFType'` in a union type to work around a circular use-before-define issue between the `SFType` and `Salesforce` classes that reference each other and are both defined in `api.py`, but I ran into issues with the typing defined that way (`SFType` methods were not seen as valid when accessing `salesforce.Account.get()`, etc.)

It seems like the proper way to fix that issue [postponed evaluation of type annotations](https://peps.python.org/pep-0563/#enabling-the-future-behavior-in-python-3-7), which I've included in this PR, but it does have possible implications for [backwards compatibility](https://peps.python.org/pep-0563/#backwards-compatibility).