### PR TITLE
Fix bulk2 upsert example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -577,7 +577,7 @@ Update existing records:
     sf.bulk2.Contact.update("./sample.csv")
 
 
-Upsert records:
+Upsert records from csv:
 
 .. code-block:: text
 
@@ -589,6 +589,19 @@ Upsert records:
 .. code-block:: python
 
     sf.bulk2.Contact.upsert(csv_file="./sample.csv", external_id_field='Custom_Id__c')
+
+
+Upsert records from dict:
+
+
+.. code-block:: python
+
+    data = [
+          {'Custom_Id__c': 'CustomID1', 'LastName': 'X'},
+          {'Custom_Id__c': 'CustomID2', 'LastName': 'Y'}
+        ]
+
+    sf.bulk2.Contact.upsert(records=df.to_dict(orient='records'), external_id_field='Custom_Id__c')
 
 
 Query records:

--- a/README.rst
+++ b/README.rst
@@ -588,7 +588,7 @@ Upsert records:
 
 .. code-block:: python
 
-    sf.bulk2.Contact.upsert("./sample.csv", 'Custom_Id__c')
+    sf.bulk2.Contact.upsert(csv_file="./sample.csv", external_id_field='Custom_Id__c')
 
 
 Query records:


### PR DESCRIPTION
Hi, I have noticed non-working example in README.

```
>>> sf.bulk2.Service__c.upsert("./user_stat.csv", 'Account_Id__c')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/y-ken/miniforge3/lib/python3.10/site-packages/simple_salesforce/bulk2.py", line 1011, in upsert
    records=_convert_dict_to_csv(
  File "/Users/y-ken/miniforge3/lib/python3.10/site-packages/simple_salesforce/bulk2.py", line 234, in _convert_dict_to_csv
    keys = set(i for s in [d.keys() for d in data] for i in s)
  File "/Users/y-ken/miniforge3/lib/python3.10/site-packages/simple_salesforce/bulk2.py", line 234, in <listcomp>
    keys = set(i for s in [d.keys() for d in data] for i in s)
AttributeError: 'str' object has no attribute 'keys'
```

I have proposed suggestion that it works.

this is based on the actual implementation. and I have also checked with my local environment.
https://github.com/simple-salesforce/simple-salesforce/blob/1d28fa18438d3840140900d4c00799798bad57b8/simple_salesforce/bulk2.py#L997-L1006

