### PR TITLE
Use JSON stream parsing for lazy bulk queries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
        'typing-extensions',
        'zeep',
        'pyjwt[crypto]',
-       'more-itertools'
+       'more-itertools',
+       'ijson'
        ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
This changeset makes Bulk API's query and query_all methods use JSON stream parsing when lazy_opeartion flag is enabled. By doing so, the methods now avoid loading the entire batch results setup into memory unnessecarily.

The code introduced can also automatically detect and handle gzip-encoded responses from the API, in cases where `Content-Encoding: gzip` header is inclued in the response.

In order to achieve this, a depedency on package `ijson` was added.