### PR TITLE
allow Metadata WSDL to be supplied at runtime

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -59,6 +59,7 @@ class Salesforce:
             parse_float: Optional[Callable[[str], Any]] = None,
             object_pairs_hook: Optional[Callable[[List[Tuple[Any, Any]]], Any]]
             = OrderedDict,
+            metadata_wsdl_path: Optional[str] = None
             ):
 
         """Initialize the instance with the given parameters.
@@ -274,6 +275,7 @@ class Salesforce:
         self.api_usage: MutableMapping[str, Union[Usage, PerAppUsage]] = {}
         self._parse_float = parse_float
         self._object_pairs_hook = object_pairs_hook  # type: ignore[assignment]
+        self.metadata_wsdl_path = metadata_wsdl_path
         self._mdapi: Optional[SfdcMetadataApi] = None
 
     @property
@@ -284,6 +286,7 @@ class Salesforce:
                                           session_id=self.session_id,
                                           instance=self.sf_instance,
                                           metadata_url=self.metadata_url,
+                                          metadata_wsdl_path=self.metadata_wsdl_path,
                                           api_version=self.sf_version,
                                           headers=self.headers
                                           )

--- a/simple_salesforce/metadata.py
+++ b/simple_salesforce/metadata.py
@@ -210,7 +210,8 @@ class SfdcMetadataApi:
             instance: str,
             metadata_url: str,
             headers: Headers,
-            api_version: Optional[str]):
+            api_version: Optional[str],
+            metadata_wsdl_path: Optional[str]):
         """ Initialize and check session """
         self.session = session
         self._session_id = session_id
@@ -219,7 +220,12 @@ class SfdcMetadataApi:
         self.headers = headers
         self._api_version = api_version
         self._deploy_zip = None
-        wsdl_path = Path(__file__).parent / 'metadata.wsdl'
+
+        if not metadata_wsdl_path:
+            wsdl_path = Path(__file__).parent / 'metadata.wsdl'
+        else:
+            wsdl_path = Path(metadata_wsdl_path)
+
         self._client = Client(
             wsdl_path.absolute().as_uri(),
             settings=Settings(


### PR DESCRIPTION
The Metadata WSDL included in the project (v51.0/Spring '21) appears to have never been updated.  Rather than requesting an update to this file, add the ability to supply our own WSDL file by indicating the path when creating the Salesforce object.

Example usage:
sf = return Salesforce(domain='test', consumer_key='...', consumer_secret='...', metadata_wsdl_path='/path/to/metadata.wsdl')