### PR TITLE
Fix: Use `client_credentials` grant type when consumer_key and consumer_secret are passed

### DIFF
--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -118,7 +118,7 @@ def SalesforceLogin(
             consumer_key is not None and \
             consumer_secret is not None:
         token_data = {
-            'grant_type': 'password',
+            'grant_type': 'client_credentials',
             'client_id': consumer_key,
             'client_secret': consumer_secret,
             'username': unescape(username),


### PR DESCRIPTION
## Description

This pull request is a one-line change to `login.py`. It updates the grant type when a `consumer_key` and `consumer_secret` are passed into `Salesforce()`. Without this change, client credentials flows fail due to an `invalid_grant` error.

I have run the test suite locally. Although I'll note that the connected apps tests passed both before _and_ after this change. Likely because of how it uses mocks rather than connecting to a real salesforce instance. If you'd like me to add an e2e test for this behavior, please let me know. 


## Related Tickets & Documents

Closes #753
[Salesforce docs about grant types for client credentials workflow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&type=5)