### PR TITLE
Fix restful method not to error out if status code is 204

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -447,6 +447,9 @@ class Salesforce:
                                        params=params,
                                        **kwargs
                                        )
+        # Some restful calls return 204 No Content, which is not JSON
+        if result.status_code == 204:
+            return None
 
         json_result = self.parse_result_to_json(result)
         if len(json_result) == 0:


### PR DESCRIPTION
When any of the restful api returns 204, this was erroring out with below error:
"""
Expecting value: line 1 column 1 (char 0)
"""
The reason was trying to parse empty string as json.