### PR TITLE
Add modular DML functionality for pre/post processing around insert/upsert/update/delete in bulk.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -550,6 +550,7 @@ This helps enables customizable pre-processing and post-load results analysis
 Python psuedo-code below, with actual code example  at the bottom of this file:
 
   .. code-block:: python
+
     class SF_Utils:
       def commit_records(self, sf, df, object, dml, success_filename = None, fallout_filename = None, batch_size = 10000, external_id_field=None):
         records_to_submit = self.reformat_df_to_SF_records(df)#format df records to sf json compatible format
@@ -557,6 +558,7 @@ Python psuedo-code below, with actual code example  at the bottom of this file:
         results_df = pd.DataFrame(results).add_prefix('RESULTS_') #add suffic to the error logging columns appended to the end of the file
         passing_df = passing + len(results_df[results_df['RESULTS_success'] == True]) #separate the uploaded data results based on success value
         fallout_df = fallout + len(results_df[results_df['RESULTS_success'] == False]) #separate the uploaded data results based on success value
+
 submit_dml - Insert records:
 
   .. code-block:: python

--- a/README.rst
+++ b/README.rst
@@ -552,6 +552,8 @@ Python psuedo-code below:
 
   .. code-block:: python
 
+    import pandas as pd
+    
     class Custom_SF_Utils:
       def reformat_df_to_SF_records(self, df):
         #format records as the author sees fit
@@ -564,7 +566,7 @@ Python psuedo-code below:
         records_to_submit = self.reformat_df_to_SF_records(df)
         #upload records to salesforce, add functionality to split upload based on upsert or not.
         results = sf.bulk.submit_dml(object, dml, records_to_submit, external_id_field)
-        #add post process reporting: add suffic to the error logging columns appended to the end of the file
+        #post process reporting: add suffix to the error logging columns appended to the end of the file
         results_df = pd.DataFrame(results).add_prefix('RESULTS_')
         #separate the uploaded data results based on success value
         passing_df = results_df[results_df['RESULTS_success'] == True]

--- a/README.rst
+++ b/README.rst
@@ -563,9 +563,9 @@ Python psuedo-code below, with actual code example  at the bottom of this file:
         #add post process reporting: add suffic to the error logging columns appended to the end of the file
         results_df = pd.DataFrame(results).add_prefix('RESULTS_')
         #separate the uploaded data results based on success value
-        passing_df = passing + len(results_df[results_df['RESULTS_success'] == True])
+        passing_df = results_df[results_df['RESULTS_success'] == True]
         #separate the uploaded data results based on success value
-        fallout_df = fallout + len(results_df[results_df['RESULTS_success'] == False])
+        fallout_df = results_df[results_df['RESULTS_success'] == False]
 
 submit_dml - Insert records:
 

--- a/README.rst
+++ b/README.rst
@@ -586,7 +586,7 @@ submit_dml - Upsert records:
           {'Email': 'foo@foo.com'}
         ]
 
-    sf.bulk.Contact.upsert(data, 'Id', batch_size=10000, use_serial=True)
+    sf.bulk.submit_dml('Contact','upsert',data, 'Id', batch_size=10000, use_serial=True)
 
 submit_dml - Delete records:
 
@@ -594,7 +594,7 @@ submit_dml - Delete records:
 
     data = [{'Id': '0000000000BBBBB'}]
 
-    sf.bulk('Contact', 'delete', data, batch_size=10000, use_serial=True)
+    sf.bulk.submit_dml('Contact', 'delete', data, batch_size=10000, use_serial=True)
 
 
 Using Bulk 2.0

--- a/README.rst
+++ b/README.rst
@@ -543,7 +543,20 @@ Hard deletion:
 
     sf.bulk.Contact.hard_delete(data,batch_size=10000,use_serial=True)
 
+The main use of the function submit_dml is to modularize
+the usage of the existing insert/upsert/update/delete operations.
 
+This helps enables customizable pre-processing and post-load results analysis
+Python psuedo-code below, with actual code example  at the bottom of this file:
+
+  .. code-block:: python
+    class SF_Utils:
+      def commit_records(self, sf, df, object, dml, success_filename = None, fallout_filename = None, batch_size = 10000, external_id_field=None):
+        records_to_submit = self.reformat_df_to_SF_records(df)#format df records to sf json compatible format
+        results = sf.bulk.commit_dml_operation(object_name, dml_operation, data, external_id_field)#upload records to salesforce
+        results_df = pd.DataFrame(results).add_prefix('RESULTS_') #add suffic to the error logging columns appended to the end of the file
+        passing_df = passing + len(results_df[results_df['RESULTS_success'] == True]) #separate the uploaded data results based on success value
+        fallout_df = fallout + len(results_df[results_df['RESULTS_success'] == False]) #separate the uploaded data results based on success value
 submit_dml - Insert records:
 
   .. code-block:: python

--- a/README.rst
+++ b/README.rst
@@ -559,7 +559,7 @@ Python psuedo-code below, with actual code example  at the bottom of this file:
         #preprocess data: format df records to sf json compatible format
         records_to_submit = self.reformat_df_to_SF_records(df)
         #upload records to salesforce
-        results = sf.bulk.submit_dml(object, dml, data, external_id_field)
+        results = sf.bulk.submit_dml(object, dml, records_to_submit, external_id_field)
         #add post process reporting: add suffic to the error logging columns appended to the end of the file
         results_df = pd.DataFrame(results).add_prefix('RESULTS_')
         #separate the uploaded data results based on success value

--- a/README.rst
+++ b/README.rst
@@ -564,7 +564,7 @@ submit_dml - Update existing records:
           {'Id': '0000000000BBBBB', 'Email': 'testnew@test.com'}
         ]
 
-    sf.bulk.Contact.update(data,batch_size=10000,use_serial=True)
+    sf.bulk.submit_dml('Contact','update',data,batch_size=10000,use_serial=True)
 
 submit_dml - Update existing records and update lookup fields from an external id field:
 

--- a/README.rst
+++ b/README.rst
@@ -548,12 +548,12 @@ the usage of the existing insert/upsert/update/delete operations.
 
 This helps enables customizable pre-processing and post-load results analysis.
 
-Python psuedo-code below:
+Python pseudo-code below:
 
   .. code-block:: python
 
     import pandas as pd
-    
+
     class Custom_SF_Utils:
       def reformat_df_to_SF_records(self, df):
         #format records as the author sees fit

--- a/README.rst
+++ b/README.rst
@@ -552,14 +552,14 @@ Python psuedo-code below, with actual code example  at the bottom of this file:
   .. code-block:: python
 
     class SF_Utils:
-      def commit_records(self, sf, df, object,
+      def submit_records(self, sf, df, object,
                          dml, success_filename = None,
                          fallout_filename = None, batch_size = 10000,
                          external_id_field=None):
         #preprocess data: format df records to sf json compatible format
         records_to_submit = self.reformat_df_to_SF_records(df)
         #upload records to salesforce
-        results = sf.bulk.commit_dml_operation(object_name, dml_operation, data, external_id_field)
+        results = sf.bulk.submit_dml(object, dml, data, external_id_field)
         #add post process reporting: add suffic to the error logging columns appended to the end of the file
         results_df = pd.DataFrame(results).add_prefix('RESULTS_')
         #separate the uploaded data results based on success value

--- a/README.rst
+++ b/README.rst
@@ -546,22 +546,23 @@ Hard deletion:
 The main use of the function submit_dml is to modularize
 the usage of the existing insert/upsert/update/delete operations.
 
-This helps enables customizable pre-processing and post-load results analysis
+This helps enables customizable pre-processing and post-load results analysis.
+
 Python psuedo-code below:
 
   .. code-block:: python
 
     class Custom_SF_Utils:
       def reformat_df_to_SF_records(self, df):
-        #format records
+        #format records as the author sees fit
         return formatted_df
       def submit_records(self, sf, df, object,
                          dml, success_filename = None,
                          fallout_filename = None, batch_size = 10000,
                          external_id_field=None):
-        #preprocess data: format df records to sf json compatible format and any other the author sees fit
+        #preprocess data: format df records to sf json compatible format
         records_to_submit = self.reformat_df_to_SF_records(df)
-        #upload records to salesforce
+        #upload records to salesforce, add functionality to split upload based on upsert or not.
         results = sf.bulk.submit_dml(object, dml, records_to_submit, external_id_field)
         #add post process reporting: add suffic to the error logging columns appended to the end of the file
         results_df = pd.DataFrame(results).add_prefix('RESULTS_')

--- a/README.rst
+++ b/README.rst
@@ -547,11 +547,14 @@ The main use of the function submit_dml is to modularize
 the usage of the existing insert/upsert/update/delete operations.
 
 This helps enables customizable pre-processing and post-load results analysis
-Python psuedo-code below, with actual code example  at the bottom of this file:
+Python psuedo-code below:
 
   .. code-block:: python
 
-    class SF_Utils:
+    class Custom_SF_Utils:
+      def reformat_df_to_SF_records(self, df):
+        #format records
+        return formatted_df
       def submit_records(self, sf, df, object,
                          dml, success_filename = None,
                          fallout_filename = None, batch_size = 10000,

--- a/README.rst
+++ b/README.rst
@@ -559,7 +559,7 @@ Python psuedo-code below:
                          dml, success_filename = None,
                          fallout_filename = None, batch_size = 10000,
                          external_id_field=None):
-        #preprocess data: format df records to sf json compatible format
+        #preprocess data: format df records to sf json compatible format and any other the author sees fit
         records_to_submit = self.reformat_df_to_SF_records(df)
         #upload records to salesforce
         results = sf.bulk.submit_dml(object, dml, records_to_submit, external_id_field)
@@ -569,6 +569,8 @@ Python psuedo-code below:
         passing_df = results_df[results_df['RESULTS_success'] == True]
         #separate the uploaded data results based on success value
         fallout_df = results_df[results_df['RESULTS_success'] == False]
+
+        #Perform any custom action with the resulting data from here as the author sees fit.
 
 submit_dml - Insert records:
 

--- a/README.rst
+++ b/README.rst
@@ -552,12 +552,20 @@ Python psuedo-code below, with actual code example  at the bottom of this file:
   .. code-block:: python
 
     class SF_Utils:
-      def commit_records(self, sf, df, object, dml, success_filename = None, fallout_filename = None, batch_size = 10000, external_id_field=None):
-        records_to_submit = self.reformat_df_to_SF_records(df)#format df records to sf json compatible format
-        results = sf.bulk.commit_dml_operation(object_name, dml_operation, data, external_id_field)#upload records to salesforce
-        results_df = pd.DataFrame(results).add_prefix('RESULTS_') #add suffic to the error logging columns appended to the end of the file
-        passing_df = passing + len(results_df[results_df['RESULTS_success'] == True]) #separate the uploaded data results based on success value
-        fallout_df = fallout + len(results_df[results_df['RESULTS_success'] == False]) #separate the uploaded data results based on success value
+      def commit_records(self, sf, df, object,
+                         dml, success_filename = None,
+                         fallout_filename = None, batch_size = 10000,
+                         external_id_field=None):
+        #format df records to sf json compatible format
+        records_to_submit = self.reformat_df_to_SF_records(df)
+        #upload records to salesforce
+        results = sf.bulk.commit_dml_operation(object_name, dml_operation, data, external_id_field)
+        #add suffic to the error logging columns appended to the end of the file
+        results_df = pd.DataFrame(results).add_prefix('RESULTS_')
+        #separate the uploaded data results based on success value
+        passing_df = passing + len(results_df[results_df['RESULTS_success'] == True])
+        #separate the uploaded data results based on success value
+        fallout_df = fallout + len(results_df[results_df['RESULTS_success'] == False])
 
 submit_dml - Insert records:
 

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ To login using a connected app, simply include the Salesforce method and pass in
     from simple_salesforce import Salesforce
     sf = Salesforce(username='myemail@example.com', password='password', consumer_key='consumer_key', consumer_secret='consumer_secret')
 
-Connected apps may also be configured with a `client_id` and `client_secret` (renamed here as `consumer_key` and `consumer_secret`), and a `domain`. 
+Connected apps may also be configured with a `client_id` and `client_secret` (renamed here as `consumer_key` and `consumer_secret`), and a `domain`.
 The `domain` for the url `https://organization.my.salesforce.com` would be `organization.my`
 
 .. code-block:: python
@@ -542,6 +542,59 @@ Hard deletion:
     data = [{'Id': '0000000000BBBBB'}]
 
     sf.bulk.Contact.hard_delete(data,batch_size=10000,use_serial=True)
+
+
+submit_dml - Insert records:
+
+  .. code-block:: python
+
+    data = [
+          {'LastName':'Smith','Email':'example@example.com'},
+          {'LastName':'Jones','Email':'test@test.com'}
+        ]
+
+    sf.bulk.submit_dml('Contact','insert',data,batch_size=10000,use_serial=True)
+
+submit_dml - Update existing records:
+
+  .. code-block:: python
+
+    data = [
+          {'Id': '0000000000AAAAA', 'Email': 'examplenew@example.com'},
+          {'Id': '0000000000BBBBB', 'Email': 'testnew@test.com'}
+        ]
+
+    sf.bulk.Contact.update(data,batch_size=10000,use_serial=True)
+
+submit_dml - Update existing records and update lookup fields from an external id field:
+
+  .. code-block:: python
+
+    data = [
+          {'Id': '0000000000AAAAA', 'Custom_Object__r': {'Email__c':'examplenew@example.com'}},
+          {'Id': '0000000000BBBBB', 'Custom_Object__r': {'Email__c': 'testnew@test.com'}}
+        ]
+
+    sf.bulk.submit_dml('Contact','update',data,batch_size=10000,use_serial=True)
+
+submit_dml - Upsert records:
+
+  .. code-block:: python
+
+    data = [
+          {'Id': '0000000000AAAAA', 'Email': 'examplenew2@example.com'},
+          {'Email': 'foo@foo.com'}
+        ]
+
+    sf.bulk.Contact.upsert(data, 'Id', batch_size=10000, use_serial=True)
+
+submit_dml - Delete records:
+
+  .. code-block:: python
+
+    data = [{'Id': '0000000000BBBBB'}]
+
+    sf.bulk('Contact', 'delete', data, batch_size=10000, use_serial=True)
 
 
 Using Bulk 2.0

--- a/README.rst
+++ b/README.rst
@@ -556,11 +556,11 @@ Python psuedo-code below, with actual code example  at the bottom of this file:
                          dml, success_filename = None,
                          fallout_filename = None, batch_size = 10000,
                          external_id_field=None):
-        #format df records to sf json compatible format
+        #preprocess data: format df records to sf json compatible format
         records_to_submit = self.reformat_df_to_SF_records(df)
         #upload records to salesforce
         results = sf.bulk.commit_dml_operation(object_name, dml_operation, data, external_id_field)
-        #add suffic to the error logging columns appended to the end of the file
+        #add post process reporting: add suffic to the error logging columns appended to the end of the file
         results_df = pd.DataFrame(results).add_prefix('RESULTS_')
         #separate the uploaded data results based on success value
         passing_df = passing + len(results_df[results_df['RESULTS_success'] == True])

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -85,7 +85,7 @@ class SFBulkHandler:
 
             The main purpose of this function is to
             build customizable reporting functions and reduce code reuse
-            in indivual execution scripts mainly with pandas
+            in individual execution scripts mainly with pandas
 
         Arguments:
 
@@ -713,7 +713,7 @@ class SFBulkType:
         """ modular bulk dml operations -
             perform insert/upsert/update/delete
             on any standard and custom objects in Salesforce."""
-        if function_name == 'upsert' and external_id_field != None:
+        if function_name == 'upsert' and external_id_field is not None:
             return getattr(self, function_name)(data,
                                                 external_id_field,
                                                 batch_size,

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -85,7 +85,7 @@ class SFBulkHandler:
 
             The main purpose of this function is to
             build customizable reporting functions and reduce code reuse
-            while reducing code in indivual execution scripts mainly with pandas
+            in indivual execution scripts mainly with pandas
 
         Arguments:
 

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -69,11 +69,11 @@ class SFBulkHandler:
                    object_name: str,
                    dml: str,
                    data: BulkDataAny,
+                   external_id_field: str = None,
                    batch_size: int = 10000,
                    use_serial: bool = False,
                    bypass_results: bool = False,
-                   include_detailed_results: bool = False,
-                   external_id_field: str = None
+                   include_detailed_results: bool = False
                    ):
         """ Perform any DML operation on any custom or
             standard object in Salesforce
@@ -104,11 +104,12 @@ class SFBulkHandler:
                           headers=self.headers,
                           session=self.session).submit_dml(dml,
                                                            data,
+                                                           external_id_field,
                                                            batch_size,
                                                            use_serial,
                                                            bypass_results,
-                                                           include_detailed_results,
-                                                           external_id_field)
+                                                           include_detailed_results
+                                                           )
 
 
 class SFBulkType:
@@ -700,11 +701,11 @@ class SFBulkType:
                 self,
                 function_name: str,
                 data: BulkDataAny,
+                external_id_field: str = None,
                 batch_size: int = 10000,
                 use_serial: bool = False,
                 bypass_results: bool = False,
-                include_detailed_results: bool = False,
-                external_id_field: str = None
+                include_detailed_results: bool = False
                 ):
         """ modular bulk dml operations -
             perform insert/upsert/update/delete

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -69,6 +69,10 @@ class SFBulkHandler:
                    object_name: str,
                    dml: str,
                    data: BulkDataAny,
+                   batch_size: int = 10000,
+                   use_serial: bool = False,
+                   bypass_results: bool = False,
+                   include_detailed_results: bool = False,
                    external_id_field: str = None
                    ):
         """ Perform any DML operation on any custom or
@@ -82,8 +86,17 @@ class SFBulkHandler:
         Arguments:
 
         * object_name       -- SF object
-        * dml               -- insert, upsert, update, delete, query, etc.
+        * dml               -- insert, upsert, update, delete
         * data              -- JSON formatted salesforce records.
+
+        Data is batched by 10,000 records by default. To pick a lower size
+        pass smaller integer to `batch_size`. to let simple-salesforce pick
+        the appropriate limit dynamically, enter `batch_size='auto'`
+
+        * batch_size        -- default to 10,000
+        * use_serial        -- default: bool = False
+        * bypass_results    -- default: bool = False,
+        * include_detailed_results  --default: bool = False,
         * external_id_field -- unique identifier field for upsert operations.
         """
         return SFBulkType(object_name=object_name,
@@ -91,6 +104,10 @@ class SFBulkHandler:
                           headers=self.headers,
                           session=self.session).submit_dml(dml,
                                                            data,
+                                                           batch_size,
+                                                           use_serial,
+                                                           bypass_results,
+                                                           include_detailed_results,
                                                            external_id_field)
 
 
@@ -683,12 +700,25 @@ class SFBulkType:
                 self,
                 function_name: str,
                 data: BulkDataAny,
+                batch_size: int = 10000,
+                use_serial: bool = False,
+                bypass_results: bool = False,
+                include_detailed_results: bool = False,
                 external_id_field: str = None
                 ):
         """ modular bulk dml operations -
             perform insert/upsert/update/delete
             on any standard and custom objects in Salesforce."""
         if function_name == 'upsert' and external_id_field != None:
-            return getattr(self, self.functions[function_name])(data, external_id_field)
+            return getattr(self, self.functions[function_name])(data,
+                                                                batch_size,
+                                                                use_serial,
+                                                                bypass_results,
+                                                                include_detailed_results,
+                                                                external_id_field)
         else:
-            return getattr(self, self.functions[function_name])(data)
+            return getattr(self, self.functions[function_name])(data,
+                                                                batch_size,
+                                                                use_serial,
+                                                                bypass_results,
+                                                                include_detailed_results)

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -79,6 +79,10 @@ class SFBulkHandler:
             standard object in Salesforce
             i.e. insert/upsert/update/delete
 
+            Required to put this function in this class due to error:
+            TypeError: 'SFBulkType' object is not callable
+            - this makes SFBulkType callable for this specific function
+
             The main purpose of this function is to
             build customizable reporting functions and reduce code reuse
             while reducing code in indivual execution scripts mainly with pandas
@@ -109,6 +113,7 @@ class SFBulkHandler:
                                                            use_serial,
                                                            bypass_results,
                                                            include_detailed_results)
+
 
 class SFBulkType:
     """ Interface to Bulk/Async API functions"""

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -65,6 +65,34 @@ class SFBulkHandler:
                           session=self.session
                           )
 
+    def submit_dml(self,
+                   object_name: str,
+                   dml: str,
+                   data: BulkDataAny,
+                   external_id_field: str = None
+                   ):
+        """ Perform any DML operation on any custom or
+            standard object in Salesforce
+            i.e. insert/upsert/update/delete
+
+            The main purpose of this function is to
+            build customizable reporting functions and reduce code reuse
+            while reducing code in indivual execution scripts mainly with pandas
+
+        Arguments:
+
+        * object_name       -- SF object
+        * dml               -- insert, upsert, update, delete, query, etc.
+        * data              -- JSON formatted salesforce records.
+        * external_id_field -- unique identifier field for upsert operations.
+        """
+        return SFBulkType(object_name=object_name,
+                          bulk_url=self.bulk_url,
+                          headers=self.headers,
+                          session=self.session).submit_dml(dml,
+                                                           data,
+                                                           external_id_field)
+
 
 class SFBulkType:
     """ Interface to Bulk/Async API functions"""
@@ -481,8 +509,8 @@ class SFBulkType:
                                            )
 
             while batch_status['state'] not in [
-                'Completed', 'Failed', 'NotProcessed'
-                ]:
+                    'Completed', 'Failed', 'NotProcessed'
+                    ]:
                 sleep(wait)
                 batch_status = self._get_batch(job_id=batch['jobId'],
                                                batch_id=batch['id']
@@ -520,8 +548,7 @@ class SFBulkType:
                                        data=data,
                                        batch_size=batch_size,
                                        bypass_results=bypass_results,
-                                       include_detailed_results=
-                                       include_detailed_results
+                                       include_detailed_results=include_detailed_results
                                        )
         return results
 
@@ -544,8 +571,7 @@ class SFBulkType:
                                        data=data,
                                        batch_size=batch_size,
                                        bypass_results=bypass_results,
-                                       include_detailed_results=
-                                       include_detailed_results
+                                       include_detailed_results=include_detailed_results
                                        )
         return results
 
@@ -570,8 +596,7 @@ class SFBulkType:
                                        data=data,
                                        batch_size=batch_size,
                                        bypass_results=bypass_results,
-                                       include_detailed_results=
-                                       include_detailed_results
+                                       include_detailed_results=include_detailed_results
                                        )
         return results
 
@@ -594,8 +619,7 @@ class SFBulkType:
                                        data=data,
                                        batch_size=batch_size,
                                        bypass_results=bypass_results,
-                                       include_detailed_results=
-                                       include_detailed_results
+                                       include_detailed_results=include_detailed_results
                                        )
         return results
 
@@ -618,8 +642,7 @@ class SFBulkType:
                                        data=data,
                                        batch_size=batch_size,
                                        bypass_results=bypass_results,
-                                       include_detailed_results=
-                                       include_detailed_results
+                                       include_detailed_results=include_detailed_results
                                        )
         return results
 
@@ -655,3 +678,17 @@ class SFBulkType:
         if lazy_operation:
             return results
         return list_from_generator(results)
+
+    def submit_dml(
+                self,
+                function_name: str,
+                data: BulkDataAny,
+                external_id_field: str = None
+                ):
+        """ modular bulk dml operations -
+            perform insert/upsert/update/delete
+            on any standard and custom objects in Salesforce."""
+        if function_name == 'upsert' and external_id_field != None:
+            return getattr(self, self.functions[function_name])(data, external_id_field)
+        else:
+            return getattr(self, self.functions[function_name])(data)

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -108,9 +108,7 @@ class SFBulkHandler:
                                                            batch_size,
                                                            use_serial,
                                                            bypass_results,
-                                                           include_detailed_results
-                                                           )
-
+                                                           include_detailed_results)
 
 class SFBulkType:
     """ Interface to Bulk/Async API functions"""
@@ -711,15 +709,15 @@ class SFBulkType:
             perform insert/upsert/update/delete
             on any standard and custom objects in Salesforce."""
         if function_name == 'upsert' and external_id_field != None:
-            return getattr(self, self.functions[function_name])(data,
-                                                                batch_size,
-                                                                use_serial,
-                                                                bypass_results,
-                                                                include_detailed_results,
-                                                                external_id_field)
+            return getattr(self, function_name)(data,
+                                                batch_size,
+                                                use_serial,
+                                                bypass_results,
+                                                include_detailed_results,
+                                                external_id_field)
         else:
-            return getattr(self, self.functions[function_name])(data,
-                                                                batch_size,
-                                                                use_serial,
-                                                                bypass_results,
-                                                                include_detailed_results)
+            return getattr(self, function_name)(data,
+                                                batch_size,
+                                                use_serial,
+                                                bypass_results,
+                                                include_detailed_results)

--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -715,11 +715,12 @@ class SFBulkType:
             on any standard and custom objects in Salesforce."""
         if function_name == 'upsert' and external_id_field != None:
             return getattr(self, function_name)(data,
+                                                external_id_field,
                                                 batch_size,
                                                 use_serial,
                                                 bypass_results,
                                                 include_detailed_results,
-                                                external_id_field)
+                                                )
         else:
             return getattr(self, function_name)(data,
                                                 batch_size,

--- a/simple_salesforce/tests/test_bulk.py
+++ b/simple_salesforce/tests/test_bulk.py
@@ -338,6 +338,266 @@ class TestSFBulkType(unittest.TestCase):
         self.assertEqual(self.expected, contact)
 
     @responses.activate
+    def test_submit_dml_using_delete(self):
+        """Test bulk delete records using the submit_dml function"""
+        operation = 'delete'
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job$'),
+            body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
+            '"contentType": "JSON","id": "Job-1","object": "Contact",'
+            f'"operation": "{operation}","state": "Open"}}',
+            status=http.OK)
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job/Job-1$'),
+            body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
+            '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
+            f'"operation" : "{operation}","state" : "Closed"}}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(
+                r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
+            body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
+            '"errors": []},{"success": true,"created": true,'
+            '"id": "001xx000003DHP1AAO","errors": []}]',
+            status=http.OK
+        )
+        data = [{
+            'id': 'ID-1',
+        }, {
+            'id': 'ID-2',
+        }]
+        session = requests.Session()
+        client = Salesforce(session_id=tests.SESSION_ID,
+                            instance_url=tests.SERVER_URL,
+                            session=session)
+        contact = client.bulk.submit_dml('Contact', 'delete', data)
+        self.assertEqual(self.expected, contact)
+
+    @responses.activate
+    def test_submit_dml_using_insert(self):
+        """Test bulk insert records using the submit_dml function"""
+        operation = 'insert'
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job$'),
+            body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
+            '"contentType": "JSON","id": "Job-1","object": "Contact",'
+            f'"operation": "{operation}","state": "Open"}}',
+            status=http.OK)
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job/Job-1$'),
+            body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
+            '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
+            f'"operation" : "{operation}","state" : "Closed"}}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(
+                r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
+            body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
+            '"errors": []},{"success": true,"created": true,'
+            '"id": "001xx000003DHP1AAO","errors": []}]',
+            status=http.OK
+        )
+
+        data = [{
+            'AccountId': 'ID-1',
+            'Email': 'contact1@example.com',
+            'FirstName': 'Bob',
+            'LastName': 'x'
+        }, {
+            'AccountId': 'ID-2',
+            'Email': 'contact2@example.com',
+            'FirstName': 'Alice',
+            'LastName': 'y'
+        }]
+        session = requests.Session()
+        client = Salesforce(session_id=tests.SESSION_ID,
+                            instance_url=tests.SERVER_URL,
+                            session=session)
+        contact = client.bulk.submit_dml('Contact', 'insert', data)
+        self.assertEqual(self.expected, contact)
+
+    @responses.activate
+    def test_submit_dml_using_upsert(self):
+        """Test bulk upsert records using submit_dml function"""
+        operation = 'upsert'
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job$'),
+            body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
+            '"contentType": "JSON","id": "Job-1","object": "Contact",'
+            f'"operation": "{operation}","state": "Open"}}',
+            status=http.OK)
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job/Job-1$'),
+            body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
+            '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
+            f'"operation" : "{operation}","state" : "Closed"}}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(
+                r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
+            body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
+            '"errors": []},{"success": true,"created": true,'
+            '"id": "001xx000003DHP1AAO","errors": []}]',
+            status=http.OK
+        )
+
+        data = [{
+            'Custom_Id__c': 'CustomID1',
+            'AccountId': 'ID-13',
+            'Email': 'contact1@example.com',
+            'FirstName': 'Bob',
+            'LastName': 'x'
+        }, {
+            'Custom_Id__c': 'CustomID2',
+            'AccountId': 'ID-24',
+            'Email': 'contact2@example.com',
+            'FirstName': 'Alice',
+            'LastName': 'y'
+        }]
+        session = requests.Session()
+        client = Salesforce(session_id=tests.SESSION_ID,
+                            instance_url=tests.SERVER_URL,
+                            session=session)
+        contact = client.bulk.submit_dml('Contact',
+                                         'upsert',
+                                         data,
+                                         'Custom_Id__c')
+        self.assertEqual(self.expected, contact)
+
+    @responses.activate
+    def test_submit_dml_using_update(self):
+        """Test bulk update records using submit_dml function"""
+        operation = 'update'
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job$'),
+            body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
+            '"contentType": "JSON","id": "Job-1","object": "Contact",'
+            f'"operation": "{operation}","state": "Open"}}',
+            status=http.OK)
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.POST,
+            re.compile(r'^https://[^/job].*/job/Job-1$'),
+            body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
+            '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
+            f'"operation" : "{operation}","state" : "Closed"}}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+            body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
+            status=http.OK
+        )
+        responses.add(
+            responses.GET,
+            re.compile(
+                r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
+            body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
+            '"errors": []},{"success": true,"created": true,'
+            '"id": "001xx000003DHP1AAO","errors": []}]',
+            status=http.OK
+        )
+
+        data = [{
+            'Id': '001xx000003DHP0AAO',
+            'AccountId': 'ID-13',
+            'Email': 'contact1@example.com',
+            'FirstName': 'Bob',
+            'LastName': 'x'
+        }, {
+            'Id': '001xx000003DHP1AAO',
+            'AccountId': 'ID-24',
+            'Email': 'contact2@example.com',
+            'FirstName': 'Alice',
+            'LastName': 'y'
+        }]
+        session = requests.Session()
+        client = Salesforce(session_id=tests.SESSION_ID,
+                            instance_url=tests.SERVER_URL,
+                            session=session)
+        contact = client.bulk.submit_dml('Contact', 'update', data)
+        self.assertEqual(self.expected, contact)
+
+    @responses.activate
     def test_query(self):
         """Test bulk query records"""
         operation = 'query'
@@ -413,7 +673,6 @@ class TestSFBulkType(unittest.TestCase):
                             session=session)
         contact = client.bulk.Contact.query(data)
         self.assertEqual(self.expected_query, contact)
-
 
     @responses.activate
     def test_query_fail(self):
@@ -691,8 +950,8 @@ class TestSFBulkType(unittest.TestCase):
             # ... and that - except for the last batch - all batches have maxed
             # out one of the two limits
             self.assertTrue(
-                is_last_batch or
-                record_count == 10_000 or
-                (size_in_bytes + len(json.dumps(result[i + 1][0])) + 2
+                is_last_batch
+                or record_count == 10_000
+                or (size_in_bytes + len(json.dumps(result[i + 1][0])) + 2
                     > 10_000_000)
             )

--- a/simple_salesforce/tests/test_bulk.py
+++ b/simple_salesforce/tests/test_bulk.py
@@ -273,7 +273,7 @@ class TestSFBulkType(unittest.TestCase):
     @responses.activate
     def test_update(self):
         """Test bulk update records"""
-        operation = 'upsert'
+        operation = 'update'
         responses.add(
             responses.POST,
             re.compile(r'^https://[^/job].*/job$'),


### PR DESCRIPTION
I have created two functions in the bulk.py file that modularize the usage of the DML (Data Manipulation Language) operations: insert/upsert/update/delete.

I have not deleted or altered any existing functionality with the exception of an issue in a unit test in test_bulk.py and some lines have been slightly reformatted by my text editor adding white space or a new line.

This new functionality allows the removal of a hardcoded insert/upsert/update/delete from an execution script with all the pre and post processing that a developer can include with it, and placing that functionality into a custom function to perform the same reporting across every object for these 4 operations.

I have added to the test_bulk .py 4 unit test and fixed a small error where the update test has operation = 'upsert' instead of = 'update'

Since there is no hard_delete unit tests in the test_bulk.py I left those out. I'm not sure how to run the unit test in the test folder to check my included unit test.
I have only tested and confirmed the functionality for the 4 operations listed with mock data from mockaroo.com, inserting/updating/upserting/deleting accounts and contacts into a dev org.

Before passing or rejecting these additions, please let me know if there any explanations or additions someone would like to see.

I can add example code from the repo I'm setting up here combining Pandas with simple_salesforce : https://github.com/tim-kornish-cloud/Data-Engineering-Practice