### PR TITLE
fix: missing key 'name' in exception message

### DIFF
--- a/simple_salesforce/exceptions.py
+++ b/simple_salesforce/exceptions.py
@@ -24,7 +24,7 @@ class SalesforceError(Exception):
             resource_name: Name of the Salesforce resource being queried
             content: content of the response
         """
-        super().__init__(self.message.format(url=url, content=content))
+        super().__init__(self.message)
         self.url = url
         self.status = status
         self.resource_name = resource_name


### PR DESCRIPTION
Test and quick fix for #794. With this PR, the exception will only be formatted when `__str__` is called on the respective exception object. In the long run, there's probably a more thorough cleanup necessary. This is just a quick solution to avoid running into these `KeyError` exceptions if SF responds with a 404.