### PR TITLE
Add Support for Custom Top-Level Domains

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -59,6 +59,7 @@ class Salesforce:
             parse_float: Optional[Callable[[str], Any]] = None,
             object_pairs_hook: Optional[Callable[[List[Tuple[Any, Any]]], Any]]
             = OrderedDict,
+            login_tld: Optional[str] = 'salesforce.com'
             ):
 
         """Initialize the instance with the given parameters.
@@ -103,11 +104,13 @@ class Salesforce:
         * proxies -- the optional map of scheme to proxy server
         * session -- Custom requests session, created in calling code. This
                      enables the use of requests Session features not otherwise
-                     exposed by simple_salesforce.
+                     exposed by py_salesforce.
         * parse_float -- Function to parse float values with. Is passed along to
                          https://docs.python.org/3/library/json.html#json.load
         * object_pairs_hook -- Function to parse ordered list of pairs in json.
                                To use python 'dict' change it to None or dict.
+        * login_tld -- The top-level domain for Salesforce URLs
+                    (default 'salesforce.com', use 'sfcrmproducts.cn' for Salesforce on Alibaba Cloud).
         """
 
         if domain is None:
@@ -148,7 +151,8 @@ class Salesforce:
                 sf_version=self.sf_version,
                 proxies=self.proxies,
                 client_id=client_id,
-                domain=self.domain
+                domain=self.domain,
+                login_tld=login_tld
                 )
             self._refresh_session()
 
@@ -192,7 +196,8 @@ class Salesforce:
                 sf_version=self.sf_version,
                 proxies=self.proxies,
                 client_id=client_id,
-                domain=self.domain
+                domain=self.domain,
+                login_tld=login_tld
                 )
             self._refresh_session()
 
@@ -210,7 +215,8 @@ class Salesforce:
                 consumer_key=consumer_key,
                 consumer_secret=consumer_secret,
                 proxies=self.proxies,
-                domain=self.domain
+                domain=self.domain,
+                login_tld=login_tld
                 )
             self._refresh_session()
 
@@ -229,7 +235,8 @@ class Salesforce:
                 privatekey_file=privatekey_file,
                 privatekey=privatekey,
                 proxies=self.proxies,
-                domain=self.domain
+                domain=self.domain,
+                login_tld=login_tld
                 )
             self._refresh_session()
         elif all(arg is not None for arg in (
@@ -243,7 +250,8 @@ class Salesforce:
                 consumer_key=consumer_key,
                 consumer_secret=consumer_secret,
                 proxies=self.proxies,
-                domain=self.domain
+                domain=self.domain,
+                login_tld=login_tld
                 )
             self._refresh_session()
         else:


### PR DESCRIPTION
## Description
This merge request adds support for custom top-level domains (TLDs) in the `SalesforceLogin` and `Salesforce` class to enable authentication with Salesforce instances using non-standard TLDs, such as `sfcrmproducts.cn` for Salesforce on Alibaba Cloud. The change addresses the limitation where the library hardcodes `.salesforce.com` in login URLs, preventing access to Salesforce on Alibaba Cloud orgs.

## Changes Made
- **New Parameter in `SalesforceLogin` and `Salesforce`**:
  - Added `login_tld: Optional[str] = 'salesforce.com'` parameter to allow specifying custom TLDs (e.g., `sfcrmproducts.cn`).
  - Updated function documentation to include `login_tld`.
- **Dynamic URL Construction**:
  - Introduced `full_domain = f"{domain}.{login_tld}"` to construct login URLs dynamically (e.g., `https://login.sfcrmproducts.cn`).
  - Modified `token_login` and SOAP login URLs to use `full_domain` instead of hardcoding `.salesforce.com`.
- **JWT Authentication**:
  - Added logic to compute the `aud` (audience) field dynamically for JWT authentication:
    - Uses `login.{login_tld}` for production environments.
    - Uses `test.{login_tld}` for sandbox environments (detected by `test`, `sandbox`, or `--` in `domain`).
  - Ensured `instance_url` respects the custom TLD when provided.
- **Backward Compatibility**:
  - Default `login_tld='salesforce.com'` preserves existing behavior.
  - No changes to other authentication flows or unrelated functionality.

## Motivation
The `simple-salesforce` library currently assumes all Salesforce instances use `.salesforce.com`, which prevents authentication with Salesforce on Alibaba Cloud orgs on `.sfcrmproducts.cn` (e.g., `login.sfcrmproducts.cn` or `mydomain.my.sfcrmproducts.cn`). This change enables users to specify custom TLDs, making the library compatible with Salesforce on Alibaba Cloud and other non-standard deployments.

## Testing
- Tested with Salesforce on Alibaba Cloud orgs using `login_tld='sfcrmproducts.cn'` for both production (`domain='login'`) and sandbox (`domain='test'`) environments.
- Verified backward compatibility with standard Salesforce orgs (`login_tld='salesforce.com'`).
- Tested password-based, JWT-based, and SOAP-based authentication flows.
- Ensured no regressions in existing functionality by running existing test cases (if applicable).

## Impact
- **Users**: Can now authenticate with Salesforce instances on custom TLDs, such as `sfcrmproducts.cn`, by passing the `login_tld` parameter.
- **Maintainers**: Minimal changes, preserving existing logic and adding only necessary modifications. The new parameter is optional, ensuring no breaking changes.
- **Dependencies**: No new dependencies introduced.

## Additional Notes
- The change assumes `instance_url` and `domain` align with the provided `login_tld` for consistency in My Domain scenarios.
- Future improvements could include adding test cases specific to custom TLDs in the test suite.

Please review and provide feedback. Happy to address any concerns or make additional adjustments!