### PR TITLE
feat: Add Support for Salesforce CLI Authentication (MFA/SSO Friendly)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,20 @@ If you have the full URL of your instance (perhaps including the scheme, as is i
     from simple_salesforce import Salesforce
     sf = Salesforce(instance_url='https://na1.salesforce.com', session_id='')
 
+**Salesforce CLI Authentication**
+
+You can authenticate using the Salesforce CLI (sf or sfdx) if you have already logged in via your terminal. This is useful for local development and scripts running in environments with the CLI installed.
+
+.. code-block:: python
+
+    from simple_salesforce import Salesforce
+
+    # Login using the default CLI org
+    sf = Salesforce(use_cli=True)
+
+    # Login using a specific org alias
+    sf = Salesforce(use_cli=True, target_org='MySandboxAlias')
+    
 There are also four means of authentication, one that uses username, password and security token; one that uses IP filtering, username, password and organizationId, one that uses a private key to sign a JWT, and one for connected apps that uses username, password, consumer key, and consumer secret;
 
 To login using the security token method, simply include the Salesforce method and pass in your Salesforce username, password and token (this is usually provided when you change your password or go to profile -> settings -> Reset My Security Token):

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -59,8 +59,8 @@ class Salesforce:
             parse_float: Optional[Callable[[str], Any]] = None,
             object_pairs_hook: Optional[Callable[[List[Tuple[Any, Any]]], Any]]
             = OrderedDict,
-            use_cli=False,
-            target_org=None,
+            use_cli: bool = False,
+            target_org: Optional[str] = None,
             ):
 
         """Initialize the instance with the given parameters.

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -22,7 +22,7 @@ from .exceptions import SalesforceGeneralError
 from .login import SalesforceLogin
 from .metadata import SfdcMetadataApi
 from .util import Headers, PerAppUsage, Proxies, Usage, date_to_iso8601, \
-    exception_handler
+    exception_handler, get_cli_session
 
 # pylint: disable=invalid-name
 logger = logging.getLogger(__name__)
@@ -59,6 +59,8 @@ class Salesforce:
             parse_float: Optional[Callable[[str], Any]] = None,
             object_pairs_hook: Optional[Callable[[List[Tuple[Any, Any]]], Any]]
             = OrderedDict,
+            use_cli=False,
+            target_org=None,
             ):
 
         """Initialize the instance with the given parameters.
@@ -97,6 +99,13 @@ class Salesforce:
         * instance_url -- Full URL of your instance i.e.
           `https://na1.salesforce.com
 
+        Salesforce CLI Authentication:
+        * use_cli -- If set to True, attempts to retrieve session details
+                     from the Salesforce CLI (sf or sfdx).
+        * target_org -- (Optional) The alias or username of the org to use
+                        when use_cli is True. If not provided, uses the
+                        CLI's default org.
+
         Universal Kwargs:
         * version -- the version of the Salesforce API to use, for example
                      `29.0`
@@ -130,6 +139,11 @@ class Salesforce:
                     'ignoring proxies: %s',
                     proxies
                     )
+
+        # If CLI is requested, fetch the Session ID and URL immediately.
+        # so the existing logic below (auth_type = "direct") processes them as if they were passed in explicitly.
+        if use_cli:
+            session_id, instance_url = get_cli_session(target_org)
 
         # Determine if the user wants to use our username/password auth or pass
         # in their own information

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -1295,3 +1295,44 @@ class TestSalesforce(unittest.TestCase):
         self.assertNotIsInstance(result, OrderedDict)
         self.assertIsInstance(result, dict)
         self.assertEqual(result, {"currency": 1.0})
+
+    """Tests for the Salesforce CLI authentication integration in api.py"""
+
+    # We patch 'simple_salesforce.api.get_cli_session' because api.py imports it.
+    # We are testing that api.py calls the helper correctly.
+    
+    @patch('simple_salesforce.api.get_cli_session')
+    def test_cli_auth_default(self, mock_get_session):
+        """Test authentication using the default CLI org (no alias provided)"""
+        
+        # 1. SETUP: Tell the helper what to return (Token, URL)
+        mock_get_session.return_value = ('FAKE_DEFAULT_TOKEN', 'https://default.salesforce.com')
+
+        # 2. RUN: Initialize Salesforce with use_cli=True
+        sf = Salesforce(use_cli=True)
+
+        # 3. VERIFY: 
+        # Did api.py correctly assign the values from the helper?
+        self.assertEqual(sf.session_id, 'FAKE_DEFAULT_TOKEN')
+        self.assertEqual(sf.sf_instance, 'default.salesforce.com')
+        self.assertEqual(sf.auth_type, 'direct') # It should behave like a direct login
+        
+        # Did api.py call the helper with None (since no target_org was passed)?
+        mock_get_session.assert_called_once_with(None)
+
+    @patch('simple_salesforce.api.get_cli_session')
+    def test_cli_auth_with_alias(self, mock_get_session):
+        """Test authentication using a specific target_org alias"""
+        
+        # 1. SETUP
+        mock_get_session.return_value = ('FAKE_ALIAS_TOKEN', 'https://alias.salesforce.com')
+
+        # 2. RUN: Initialize with an alias
+        sf = Salesforce(use_cli=True, target_org='UAT_Sandbox')
+
+        # 3. VERIFY
+        self.assertEqual(sf.session_id, 'FAKE_ALIAS_TOKEN')
+        self.assertEqual(sf.sf_instance, 'alias.salesforce.com')
+        
+        # Did api.py pass the alias string to the helper?
+        mock_get_session.assert_called_once_with('UAT_Sandbox')

--- a/simple_salesforce/tests/test_util.py
+++ b/simple_salesforce/tests/test_util.py
@@ -149,13 +149,13 @@ class TestUtilCli(unittest.TestCase):
 
     @patch('shutil.which')
     def test_cli_not_found(self, mock_which):
-        """Test that we raise an Exception if neither sf nor sfdx is found"""
+        """Test that we raise ValueError if neither sf nor sfdx is found"""
         
         # Setup: Return None for both checks
         mock_which.return_value = None
         
-        # Verify it raises the generic Exception you defined
-        with self.assertRaises(Exception) as context:
+        # Verify it raises ValueError
+        with self.assertRaises(ValueError) as context:
             get_cli_session()
         
         self.assertIn("Salesforce CLI not found", str(context.exception))

--- a/simple_salesforce/tests/test_util.py
+++ b/simple_salesforce/tests/test_util.py
@@ -11,8 +11,12 @@ from simple_salesforce.exceptions import (SalesforceExpiredSession,
                                           SalesforceRefusedRequest,
                                           SalesforceResourceNotFound)
 from simple_salesforce.util import (date_to_iso8601, exception_handler,
-                                    getUniqueElementValueFromXmlString)
+                                    getUniqueElementValueFromXmlString,
+                                    get_cli_session)
 
+import json
+import subprocess
+from unittest.mock import patch
 
 class TestXMLParser(unittest.TestCase):
     """Test the XML parser utility function"""
@@ -105,3 +109,90 @@ class TestExceptionHandler(unittest.TestCase):
         self.assertEqual(str(cm.exception), (
             'Error Code 500. Response content'
             ': Example Content'))
+
+class TestUtilCli(unittest.TestCase):
+    
+    # 1. We mock 'shutil.which' to pretend we found the installed CLI
+    @patch('shutil.which')
+    # 2. We mock 'subprocess.run' to fake the execution
+    @patch('subprocess.run')
+    def test_get_cli_session_success(self, mock_subprocess, mock_which):
+        """Test parsing valid JSON when 'sf' is found"""
+        
+        # A. Setup 'shutil.which' to return a fake path
+        # This simulates finding the CLI at /usr/bin/sf
+        mock_which.return_value = '/usr/bin/sf'
+
+        # B. Setup 'subprocess' to return valid JSON
+        mock_result = Mock()
+        mock_result.stdout = json.dumps({
+            "status": 0,
+            "result": {
+                "accessToken": "REAL_TOKEN",
+                "instanceUrl": "https://real-instance.salesforce.com"
+            }
+        })
+        mock_subprocess.return_value = mock_result
+
+        # C. Run the function
+        token, url = get_cli_session()
+
+        # D. Verify Logic
+        self.assertEqual(token, "REAL_TOKEN")
+        
+        # Verify it verified the existence of 'sf' first
+        mock_which.assert_called_with('sf')
+        
+        # Verify it used the path returned by shutil (/usr/bin/sf)
+        args, _ = mock_subprocess.call_args
+        self.assertEqual(args[0][0], '/usr/bin/sf')
+
+    @patch('shutil.which')
+    def test_cli_not_found(self, mock_which):
+        """Test that we raise an Exception if neither sf nor sfdx is found"""
+        
+        # Setup: Return None for both checks
+        mock_which.return_value = None
+        
+        # Verify it raises the generic Exception you defined
+        with self.assertRaises(Exception) as context:
+            get_cli_session()
+        
+        self.assertIn("Salesforce CLI not found", str(context.exception))
+
+    @patch('shutil.which')
+    @patch('subprocess.run')
+    def test_get_cli_session_with_alias(self, mock_subprocess, mock_which):
+        # 1. Setup
+        mock_which.return_value = '/bin/sf'
+        mock_subprocess.return_value.stdout = '{"result": {"accessToken": "x", "instanceUrl": "y"}}'
+
+        # 2. This runs the function WITH an argument, forcing it into the 'if target_org' block
+        get_cli_session(target_org="MyAlias")
+        
+        # 3. Verify the command list actually grew larger
+        args, _ = mock_subprocess.call_args
+        self.assertIn('--target-org', args[0])
+    
+    @patch('shutil.which')
+    @patch('subprocess.run')
+    def test_get_cli_runtime_error(self, mock_subprocess, mock_which):
+        """Test the specific block: except subprocess.CalledProcessError"""
+        
+        # 1. CRITICAL: We must pretend 'sf' exists so the code proceeds to the try/except block
+        mock_which.return_value = '/bin/sf'
+
+        # 2. CRITICAL: We force subprocess to RAISE an error (simulating a crash)
+        # We simulate a "Session Expired" error from the CLI
+        # args: (returncode, cmd, output, stderr)
+        fake_error = subprocess.CalledProcessError(1, ['sf'], output="", stderr="Session expired")
+        mock_subprocess.side_effect = fake_error
+
+        # 3. VERIFY
+        # Your code catches CalledProcessError and raises ValueError
+        # So we assert that ValueError is raised
+        with self.assertRaises(ValueError) as context:
+            get_cli_session()
+            
+        # 4. Check if we caught the error message
+        self.assertIn("Session expired", str(context.exception))

--- a/simple_salesforce/tests/test_util.py
+++ b/simple_salesforce/tests/test_util.py
@@ -1,7 +1,9 @@
 """Tests for simple-salesforce utility functions"""
 import datetime
+import json
+import subprocess
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytz
 from simple_salesforce.exceptions import (SalesforceExpiredSession,
@@ -13,10 +15,6 @@ from simple_salesforce.exceptions import (SalesforceExpiredSession,
 from simple_salesforce.util import (date_to_iso8601, exception_handler,
                                     getUniqueElementValueFromXmlString,
                                     get_cli_session)
-
-import json
-import subprocess
-from unittest.mock import patch
 
 class TestXMLParser(unittest.TestCase):
     """Test the XML parser utility function"""

--- a/simple_salesforce/util.py
+++ b/simple_salesforce/util.py
@@ -9,7 +9,6 @@ from typing import Any, Iterable, List, Mapping, MutableMapping, NamedTuple, \
     NoReturn, \
     Optional, \
     Tuple, TypeVar, Union
-from urllib.parse import urlparse
 
 import requests
 

--- a/simple_salesforce/util.py
+++ b/simple_salesforce/util.py
@@ -126,10 +126,10 @@ def list_from_generator(
 def get_cli_session(target_org: Optional[str] = None) -> Tuple[str, str]:
     """
     Helper to get session from Salesforce CLI (sf).
-    
+
     Args:
         target_org: Optional alias or username of the org to use
-        
+
     Returns:
         A tuple of (access_token, instance_url)
     """
@@ -144,19 +144,19 @@ def get_cli_session(target_org: Optional[str] = None) -> Tuple[str, str]:
 
     if target_org:
         command.extend(['--target-org', target_org])
-        
+
     try:
         # check=True ensures we raise an error if command fails
         result = subprocess.run(
-            command, 
-            capture_output=True, 
-            text=True, 
+            command,
+            capture_output=True,
+            text=True,
             check=True
         )
         data = json.loads(result.stdout)
 
         return data['result']['accessToken'], data['result']['instanceUrl']
-        
+
     except subprocess.CalledProcessError as e:
         err_msg = e.stderr if e.stderr else str(e)
         raise ValueError(f"Salesforce CLI failed: {err_msg}")

--- a/simple_salesforce/util.py
+++ b/simple_salesforce/util.py
@@ -1,11 +1,15 @@
 """Utility functions for simple-salesforce"""
 
 import datetime
+import json
+import shutil
+import subprocess
 import xml.dom.minidom
 from typing import Any, Iterable, List, Mapping, MutableMapping, NamedTuple, \
     NoReturn, \
     Optional, \
     Tuple, TypeVar, Union
+from urllib.parse import urlparse
 
 import requests
 
@@ -13,11 +17,6 @@ from .exceptions import (SalesforceExpiredSession, SalesforceGeneralError,
                          SalesforceMalformedRequest,
                          SalesforceMoreThanOneRecord, SalesforceRefusedRequest,
                          SalesforceResourceNotFound)
-
-from urllib.parse import urlparse
-import json
-import subprocess
-import shutil
 
 Headers = MutableMapping[str, str]
 Proxies = MutableMapping[str, str]
@@ -134,7 +133,7 @@ def get_cli_session(target_org: Optional[str] = None) -> Tuple[str, str]:
         A tuple of (access_token, instance_url)
     """
 
-    # 1. Find the full path to the executable
+    # Find the Salesforce CLI executable (sf or sfdx)
     executable = shutil.which("sf") or shutil.which("sfdx")
 
     if not executable:

--- a/simple_salesforce/util.py
+++ b/simple_salesforce/util.py
@@ -14,6 +14,11 @@ from .exceptions import (SalesforceExpiredSession, SalesforceGeneralError,
                          SalesforceMoreThanOneRecord, SalesforceRefusedRequest,
                          SalesforceResourceNotFound)
 
+from urllib.parse import urlparse
+import json
+import subprocess
+import shutil
+
 Headers = MutableMapping[str, str]
 Proxies = MutableMapping[str, str]
 BulkDataAny = List[Mapping[str, Any]]
@@ -117,3 +122,35 @@ def list_from_generator(
     for list_results in generator_function:
         ret_val.extend(list_results)
     return ret_val
+
+def get_cli_session(target_org=None):
+    """
+    Helper to get session from Salesforce CLI (sf).
+    """
+
+    # 1. Find the full path to the executable
+    executable = shutil.which("sf") or shutil.which("sfdx")
+
+    if not executable:
+        raise Exception("Salesforce CLI not found. Please install it from: https://developer.salesforce.com/tools/salesforcecli or check your PATH.")
+
+    command = [executable, 'org', 'display', '--json']
+
+    if target_org:
+        command.extend(['--target-org', target_org])
+        
+    try:
+        # check=True ensures we raise an error if command fails
+        result = subprocess.run(
+            command, 
+            capture_output=True, 
+            text=True, 
+            check=True
+        )
+        data = json.loads(result.stdout)
+
+        return data['result']['accessToken'], data['result']['instanceUrl']
+        
+    except subprocess.CalledProcessError as e:
+        err_msg = e.stderr if e.stderr else str(e)
+        raise ValueError(f"Salesforce CLI failed: {err_msg}")

--- a/simple_salesforce/util.py
+++ b/simple_salesforce/util.py
@@ -5,7 +5,7 @@ import xml.dom.minidom
 from typing import Any, Iterable, List, Mapping, MutableMapping, NamedTuple, \
     NoReturn, \
     Optional, \
-    TypeVar, Union
+    Tuple, TypeVar, Union
 
 import requests
 
@@ -123,16 +123,22 @@ def list_from_generator(
         ret_val.extend(list_results)
     return ret_val
 
-def get_cli_session(target_org=None):
+def get_cli_session(target_org: Optional[str] = None) -> Tuple[str, str]:
     """
     Helper to get session from Salesforce CLI (sf).
+    
+    Args:
+        target_org: Optional alias or username of the org to use
+        
+    Returns:
+        A tuple of (access_token, instance_url)
     """
 
     # 1. Find the full path to the executable
     executable = shutil.which("sf") or shutil.which("sfdx")
 
     if not executable:
-        raise Exception("Salesforce CLI not found. Please install it from: https://developer.salesforce.com/tools/salesforcecli or check your PATH.")
+        raise ValueError("Salesforce CLI not found. Please install it from: https://developer.salesforce.com/tools/salesforcecli or check your PATH.")
 
     command = [executable, 'org', 'display', '--json']
 


### PR DESCRIPTION
## Motivation
Salesforce is actively deprecating the legacy SOAP login API (username/password). Users are now seeing warnings such as:
> *"SOAP API login() is disabled by default... and will be retired in the Summer '27 release."*

Combined with strict MFA (Multi-Factor Authentication) enforcement, this makes the traditional login method difficult or impossible for many users. This PR provides a future-proof alternative by allowing `simple-salesforce` to use the authenticated session from the **Salesforce CLI**, which handles MFA and SSO natively.

## The Solution
This PR allows `simple-salesforce` to piggyback off the official **Salesforce CLI** (`sf` or `sfdx`). If a user is already logged in locally (via web browser flow), this library can now utilize that valid session instantly.

## Changes
* **`api.py`**: Updated `Salesforce.__init__` to accept `use_cli=True` and `target_org='alias'`.
* **`util.py`**: Added `get_cli_session()` to securely fetch the access token and instance URL via a subprocess call.
* **Tests**: Added full test coverage for success scenarios, aliases, missing CLI tools, and runtime errors.

## Usage Example
```python
from simple_salesforce import Salesforce

# No password or token needed if you are logged in via CLI
sf = Salesforce(use_cli=True)

# Works with specific aliases
sf = Salesforce(use_cli=True, target_org='MySandbox')