### PR TITLE
fixed the authentication issue related to client credentials via exte…

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -56,6 +56,7 @@ class Salesforce:
             consumer_secret: Optional[str] = None,
             privatekey_file: Optional[str] = None,
             privatekey: Optional[str] = None,
+            auth_type: Optional[str] = None,
             parse_float: Optional[Callable[[str], Any]] = None,
             object_pairs_hook: Optional[Callable[[List[Tuple[Any, Any]]], Any]]
             = OrderedDict,
@@ -109,6 +110,8 @@ class Salesforce:
         * object_pairs_hook -- Function to parse ordered list of pairs in json.
                                To use python 'dict' change it to None or dict.
         """
+        if auth_type not in ('password', 'jwt-bearer', 'direct','ipfilter','client-credentials'):
+            raise ValueError("Invalid auth_type specified")
 
         if domain is None:
             domain = 'login'
@@ -120,6 +123,7 @@ class Salesforce:
         self.session = session or requests.Session()
         self.proxies = self.session.proxies
         self._salesforce_login_partial = None
+        self.auth_type = auth_type
         # override custom session proxies dance
         if proxies is not None:
             if not session:
@@ -135,8 +139,7 @@ class Salesforce:
         # in their own information
         if all(arg is not None for arg in (
                 username, password, security_token)
-               ):
-            self.auth_type = "password"
+               ) and self.auth_type == "password":
 
             # Pass along the username/password to our login helper
             self._salesforce_login_partial = partial(
@@ -154,8 +157,7 @@ class Salesforce:
 
         elif all(arg is not None for arg in (
                 session_id, instance or instance_url)
-                 ):
-            self.auth_type = "direct"
+                 ) and self.auth_type == "direct":
             self.session_id: str = cast(str,
                                         session_id
                                         )
@@ -179,8 +181,7 @@ class Salesforce:
 
         elif all(arg is not None for arg in (
                 username, password, organizationId)
-                 ):
-            self.auth_type = 'ipfilter'
+                 ) and self.auth_type == 'ipfilter':
 
             # Pass along the username/password to our login helper
             self._salesforce_login_partial = partial(
@@ -198,8 +199,7 @@ class Salesforce:
 
         elif all(arg is not None for arg in (
                 username, password, consumer_key, consumer_secret)
-                 ):
-            self.auth_type = "password"
+                 ) and self.auth_type == "password":
 
             # Pass along the username/password to our login helper
             self._salesforce_login_partial = partial(
@@ -216,8 +216,8 @@ class Salesforce:
 
         elif all(arg is not None for arg in (
                 username, consumer_key, privatekey_file or privatekey)
-                 ):
-            self.auth_type = "jwt-bearer"
+                 ) and self.auth_type == 'jwt-bearer':
+            
 
             # Pass along the username/password to our login helper
             self._salesforce_login_partial = partial(
@@ -234,16 +234,16 @@ class Salesforce:
             self._refresh_session()
         elif all(arg is not None for arg in (
                 consumer_key, consumer_secret, domain
-                )
-                 ):
-            self.auth_type = "client-credentials"
+                )) and self.auth_type == 'client-credentials':
+            
             self._salesforce_login_partial = partial(
                 SalesforceLogin,
                 session=self.session,
                 consumer_key=consumer_key,
                 consumer_secret=consumer_secret,
                 proxies=self.proxies,
-                domain=self.domain
+                domain=self.domain,
+                instance_url=instance_url
                 )
             self._refresh_session()
         else:

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -3,7 +3,7 @@
 Heavily Modified from RestForce 1.0.0
 """
 from typing import Any, Dict, Optional, Tuple, Union, cast
-import base64
+import base64,logging
 
 DEFAULT_CLIENT_ID_PREFIX = 'simple-salesforce'
 
@@ -21,6 +21,8 @@ from .api import DEFAULT_API_VERSION
 from .exceptions import SalesforceAuthenticationFailed
 from .util import Headers, Proxies, getUniqueElementValueFromXmlString
 
+logging.basicConfig
+logger = logging.getLogger(__name__)
 
 # pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-branches
 def SalesforceLogin(
@@ -119,7 +121,7 @@ def SalesforceLogin(
     elif username is not None and \
             password is not None and \
             consumer_key is not None and \
-            consumer_secret is not None:
+            consumer_secret is not None and instance_url is None:
         token_data = {
             'grant_type': 'password',
             'client_id': consumer_key,
@@ -216,6 +218,19 @@ def SalesforceLogin(
             f'https://{token_domain}.salesforce.com/services/oauth2/token',
             token_data, domain, consumer_key,
             None, proxies, session)
+    elif instance_url is not None and \
+            consumer_key is not None and \
+            consumer_secret is not None:
+        token_data = {'grant_type': 'client_credentials',
+                      'client_id': consumer_key,
+                      'client_secret': consumer_secret}
+        headers = {'content-type': 'application/x-www-form-urlencoded'}
+        
+        return token_login(
+            f'{instance_url}/services/oauth2/token',
+            token_data, instance_url, consumer_key,
+            headers, proxies, session)
+
     elif consumer_key is not None and consumer_secret is not None and \
             domain is not None and domain not in ('login', 'test'):
         token_data = {'grant_type': 'client_credentials'}
@@ -229,6 +244,16 @@ def SalesforceLogin(
             token_data, domain, consumer_key,
             headers, proxies, session)
     else:
+
+        logger.debug('token data: %s',
+                    {'grant_type': 'client_credentials',
+                      'client_id': consumer_key,
+                      'client_secret': consumer_secret,
+                      'username': username,
+                      'password': password,
+                      'instance_url': instance_url,
+                        'domain': domain})
+        
         except_code = 'INVALID AUTH'
         except_msg = (
             'You must submit either a security token or organizationId for '


### PR DESCRIPTION
The current simple-salesforce implementation only supports username/password authentication flows, which is incompatible with Salesforce's newer External Connected App configuration that uses OAuth 2.0 Client Credentials flow for server-to-server authentication without requiring user credentials.

This PR adds support for the OAuth 2.0 Client Credentials flow, avoid username and password exposure during the authentication process using only:
Client ID (Consumer Key)
Client Secret (Consumer Secret)