### PR TITLE
fix: Add __all__ to __init__.py to fix type checker re-export errors

### DIFF
--- a/simple_salesforce/__init__.py
+++ b/simple_salesforce/__init__.py
@@ -10,3 +10,20 @@ from .exceptions import (SalesforceAuthenticationFailed, SalesforceError,
                          SalesforceResourceNotFound)
 from .login import SalesforceLogin
 from .format import format_soql, format_external_id
+
+__all__ = [
+    "Salesforce",
+    "SFType",
+    "SFBulkHandler",
+    "SalesforceAuthenticationFailed",
+    "SalesforceError",
+    "SalesforceExpiredSession",
+    "SalesforceGeneralError",
+    "SalesforceMalformedRequest",
+    "SalesforceMoreThanOneRecord",
+    "SalesforceRefusedRequest",
+    "SalesforceResourceNotFound",
+    "SalesforceLogin",
+    "format_soql",
+    "format_external_id",
+]


### PR DESCRIPTION
`__init__.py` re-imports names like `Salesforce` without declaring `__all__` or using the `as` re-export pattern. Since the package has a `py.typed` marker, type checkers treat these as private:

mypy with `--no-implicit-reexport` or `--strict`: 
	`Module "simple_salesforce" does not explicitly export attribute "Salesforce" [attr-defined]`
	
pyright (default settings): 
	`"Salesforce" is not exported from module "simple_salesforce" (reportPrivateImportUsage)`

This adds an `__all__` listing the 14 names already imported. No imports added or removed, no other files changed. Runtime behavior is unaffected.

Tested with mypy --strict and pyright, both pass.
Closes #723