### PR TITLE
Add PyPI publish workflow with trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          python -m pip install build
 
       - name: Build package
         run: python -m build
@@ -48,7 +48,6 @@ jobs:
       url: https://pypi.org/p/simple-salesforce
     permissions:
       contents: read
-      actions: read
       id-token: write
     steps:
       - name: Download distribution artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/simple-salesforce
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/publish.yml`) that publishes to PyPI on `v*` tag pushes
- A `build` job produces the sdist/wheel with `python -m build` and uploads them as artifacts; a tag-gated `publish` job then publishes via `pypa/gh-action-pypi-publish` using OIDC trusted publishing (no API token) through a `pypi` environment

## Verification
- Package builds cleanly with `python -m build` using the existing `setuptools>=61.0` / `build_meta` build system (no pyproject changes needed)
- Both artifacts pass `twine check`; the wheel includes `metadata.wsdl` and `py.typed`
- Existing tags already follow the `v1.12.x` format matching the `v*` trigger

## Before first use
- Add a trusted publisher on the PyPI project: owner `simple-salesforce`, repo `simple-salesforce`, workflow `publish.yml`, environment `pypi`
- The published version comes from `simple_salesforce/__version__.py`, not the tag — bump it before tagging the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)