### PR TITLE
Add Python 3.14 support and make CI actually run the test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         toxenv: [unit]
         include:
           - python-version: "3.10"

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,22 @@
+v1.12.10
+========
+Features
+--------
+
+- [#825] Add Python 3.14 support
+
+Bug fixes
+---------
+
+- [#825] Fix SalesforceAuthenticationFailed raising TypeError when the
+  Salesforce error response has no error_description
+
+Other
+-----
+
+- [#824] Publish to PyPI via GitHub Actions trusted publishing
+- [#825] Fix CI so the tox test envs actually run the test suite
+
 v1.12.9
 =======
 Bug fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 

--- a/simple_salesforce/__version__.py
+++ b/simple_salesforce/__version__.py
@@ -5,7 +5,7 @@ This file shamelessly taken from the requests library"""
 __title__ = 'simple-salesforce'
 __description__ = 'A basic Salesforce.com REST API client.'
 __url__ = 'https://github.com/simple-salesforce/simple-salesforce'
-__version__ = '1.12.9'
+__version__ = '1.12.10'
 __author__ = 'Nick Catalano'
 __author_email__ = 'nickcatal@gmail.com'
 __license__ = 'Apache 2.0'

--- a/simple_salesforce/exceptions.py
+++ b/simple_salesforce/exceptions.py
@@ -1,5 +1,5 @@
 """All exceptions for Simple Salesforce"""
-from typing import Union
+from typing import Optional, Union
 
 
 class SalesforceError(Exception):
@@ -107,18 +107,19 @@ class SalesforceAuthenticationFailed(SalesforceError):
 
     message = 'Authentication failed. Response content: {content}'
 
-    def __init__(self, code: Union[str, int, None], auth_message: str) -> None:
+    def __init__(self, code: Union[str, int, None],
+                 auth_message: Optional[str]) -> None:
         """Initialize SalesforceAuthenticationFailed exception.
 
         Args:
             code: Error code from Salesforce (can be string, int, or None)
-            auth_message: Authentication failure message
-
-        Raises:
-            TypeError: If auth_message is not a string
+            auth_message: Authentication failure message. Salesforce error
+                responses may omit ``error_description``, so a non-string
+                (e.g. None) is coerced rather than rejected — raising
+                TypeError here would mask the authentication failure.
         """
         if not isinstance(auth_message, str):
-            raise TypeError("auth_message must be a string")
+            auth_message = '' if auth_message is None else str(auth_message)
 
         # Provide minimal context expected by SalesforceError.__init__
         url = 'authentication_endpoint'

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -213,6 +213,9 @@ class TestSalesforceLogin(unittest.TestCase):
             'response': on_response,
             }
         with warnings.catch_warnings(record=True) as warning:
+            # override the project-wide "ignore::UserWarning" filter so
+            # the warning is actually recorded
+            warnings.simplefilter("always")
             with self.assertRaises(SalesforceAuthenticationFailed):
                 # pylint: disable=unused-variable
                 session_id, instance = SalesforceLogin(

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -213,9 +213,7 @@ class TestSalesforceLogin(unittest.TestCase):
             'response': on_response,
             }
         with warnings.catch_warnings(record=True) as warning:
-            # override the project-wide "ignore::UserWarning" filter so
-            # the warning is actually recorded
-            warnings.simplefilter("always")
+            warnings.simplefilter("always", UserWarning)
             with self.assertRaises(SalesforceAuthenticationFailed):
                 # pylint: disable=unused-variable
                 session_id, instance = SalesforceLogin(

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ commands =
     pytest {posargs}
 
 [testenv:static]
+extras =
 deps = .[lint]
 commands =
     - pylint --rcfile=.pylintrc -rn simple_salesforce
@@ -38,6 +39,7 @@ commands =
 
 
 [testenv:docs]
+extras =
 deps =
     sphinx
     sphinx-rtd-theme

--- a/tox.ini
+++ b/tox.ini
@@ -1,30 +1,34 @@
 [tox]
 minversion = 4.0
-envlist = py{39,310,311,312,313}-unit, static
+envlist = py{39,310,311,312,313,314}-unit, static
 isolated_build = true
 
 [gh]
 python =
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    3.12: py312
-    3.13: py313
+    3.9: py39-unit
+    3.10: py310-unit
+    3.11: py311-unit
+    3.12: py312-unit
+    3.13: py313-unit
+    3.14: py314-unit
 
+# The base testenv runs the unit suite, so both the per-version
+# py3XX-unit envs and the version-agnostic "unit" env used by CI
+# (TOXENV=unit under the matrix interpreter) actually run the tests.
 [testenv]
 package = editable
+extras = test
 setenv =
     COVERAGE_FILE = {envtmpdir}/.coverage
 passenv =
     CI
     GITHUB_*
     CODECOV_*
-
-[testenv:py{39,310,311,312,313}-unit]
+# pytest-cov (configured via addopts in pyproject.toml) handles coverage
+# run/report/xml/fail-under; wrapping pytest in "coverage run" as well
+# makes the outer run collect nothing and report 0%.
 commands =
-    coverage run --source=simple_salesforce -m pytest {posargs}
-    coverage report --show-missing --fail-under=62
-    coverage xml
+    pytest {posargs}
 
 [testenv:static]
 deps = .[lint]


### PR DESCRIPTION
Closes #823

## Summary
- Declares Python 3.14 support in the PyPI classifiers, the CI test matrix, and the tox envlist
- Fixes the CI test jobs, which were silently no-ops: `TOXENV: unit` matched no defined tox env, so tox created an implicit env that installed dependencies and ran **zero commands** — every matrix job has been green without ever running pytest
- Fixes the failures the newly-running suite exposed (details below)

## CI fix
The unit suite now lives in the base `[testenv]` (with `extras = test`, which the unit envs never declared), so both the version-agnostic `unit` env CI uses and the per-version `py3XX-unit` envs really run pytest under the matrix interpreter. The redundant outer `coverage run` wrapper is dropped — pytest-cov (configured in pyproject `addopts`) does the measurement, and the wrapper collected nothing, reporting 0% and failing the coverage gate.

## Test failures fixed (pre-existing on all versions, not 3.14-specific)
- **`SalesforceAuthenticationFailed` raised `TypeError` for non-string messages** (introduced in #770's refactor). Salesforce error responses can omit `error_description`, so `json_response.get('error_description')` can be `None` — callers then got `TypeError` instead of the documented `SalesforceAuthenticationFailed`. Non-strings are now coerced.
- **`test_token_login_failure_with_warning` recorded no warnings** — the project-wide `ignore::UserWarning` filter in pyproject applies inside `catch_warnings(record=True)`; the test now sets `simplefilter("always")`.

## Verification
- Python 3.14.x (Homebrew): `tox -e py314-unit` → **187 passed, 24 skipped**, coverage 70.63% (gate 62%)
- CI-style path `TOXENV=unit tox` → same result
- Same 3 test failures reproduced on Python 3.12 before the fixes, confirming they were pre-existing rather than 3.14 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)